### PR TITLE
feat: persist settlement in Split aggregate for later retrieval

### DIFF
--- a/fairnsquare-app/src/main/java/org/asymetrik/web/fairnsquare/split/api/dto/SplitResponseDTO.java
+++ b/fairnsquare-app/src/main/java/org/asymetrik/web/fairnsquare/split/api/dto/SplitResponseDTO.java
@@ -12,7 +12,8 @@ import org.asymetrik.web.fairnsquare.expense.api.dto.ExpenseDTO;
  */
 public record SplitResponseDTO(@JsonProperty("id") String id, @JsonProperty("name") String name,
         @JsonProperty("createdAt") String createdAt, @JsonProperty("participants") List<ParticipantDTO> participants,
-        @JsonProperty("expenses") List<ExpenseDTO> expenses) {
+        @JsonProperty("expenses") List<ExpenseDTO> expenses,
+        @JsonProperty("settlement") SettlementResponseDTO settlement) {
 
     @JsonCreator
     public SplitResponseDTO {

--- a/fairnsquare-app/src/main/java/org/asymetrik/web/fairnsquare/split/api/mapper/SplitMapper.java
+++ b/fairnsquare-app/src/main/java/org/asymetrik/web/fairnsquare/split/api/mapper/SplitMapper.java
@@ -1,6 +1,7 @@
 package org.asymetrik.web.fairnsquare.split.api.mapper;
 
 import org.asymetrik.web.fairnsquare.expense.api.mapper.ExpenseMapper;
+import org.asymetrik.web.fairnsquare.split.api.dto.SettlementResponseDTO;
 import org.asymetrik.web.fairnsquare.split.api.dto.SplitResponseDTO;
 import org.asymetrik.web.fairnsquare.split.domain.Split;
 
@@ -15,11 +16,14 @@ public class SplitMapper {
 
     private final ParticipantMapper participantMapper;
     private final ExpenseMapper expenseMapper;
+    private final SettlementMapper settlementMapper;
 
     @Inject
-    public SplitMapper(ParticipantMapper participantMapper, ExpenseMapper expenseMapper) {
+    public SplitMapper(ParticipantMapper participantMapper, ExpenseMapper expenseMapper,
+            SettlementMapper settlementMapper) {
         this.participantMapper = participantMapper;
         this.expenseMapper = expenseMapper;
+        this.settlementMapper = settlementMapper;
     }
 
     /**
@@ -38,8 +42,12 @@ public class SplitMapper {
             throw new NullPointerException("Split cannot be null");
         }
 
+        SettlementResponseDTO settlementDTO = split.getSettlement() != null
+                ? settlementMapper.toDTO(split.getSettlement())
+                : null;
+
         return new SplitResponseDTO(split.getId().value(), split.getName().value(), split.getCreatedAt().toString(),
                 split.getParticipants().stream().map(participantMapper::toDTO).toList(),
-                split.getExpenses().stream().map(e -> expenseMapper.toDTO(e, split)).toList());
+                split.getExpenses().stream().map(e -> expenseMapper.toDTO(e, split)).toList(), settlementDTO);
     }
 }

--- a/fairnsquare-app/src/main/java/org/asymetrik/web/fairnsquare/split/domain/Split.java
+++ b/fairnsquare-app/src/main/java/org/asymetrik/web/fairnsquare/split/domain/Split.java
@@ -15,6 +15,7 @@ import org.asymetrik.web.fairnsquare.split.domain.participant.DuplicateParticipa
 import org.asymetrik.web.fairnsquare.split.domain.participant.Participant;
 import org.asymetrik.web.fairnsquare.split.domain.participant.ParticipantHasExpensesError;
 import org.asymetrik.web.fairnsquare.split.domain.participant.ParticipantNotFoundError;
+import org.asymetrik.web.fairnsquare.split.domain.settlement.Settlement;
 
 import com.aventrix.jnanoid.jnanoid.NanoIdUtils;
 
@@ -47,6 +48,7 @@ public class Split {
     private final Instant createdAt;
     private final List<Participant> participants;
     private final List<Expense> expenses;
+    private Settlement settlement;
 
     /**
      * Factory method to create a new Split with generated ID.
@@ -109,6 +111,7 @@ public class Split {
             throw new IllegalArgumentException("Participant cannot be null");
         }
         this.participants.add(participant);
+        clearSettlement();
         validate();
     }
 
@@ -120,6 +123,7 @@ public class Split {
             throw new IllegalArgumentException("Expense cannot be null");
         }
         this.expenses.add(expense);
+        clearSettlement();
         validate();
     }
 
@@ -144,6 +148,7 @@ public class Split {
                 Participant updated = new Participant(participantId, new Participant.Name(newName),
                         new Participant.Nights(newNights));
                 participants.set(i, updated);
+                clearSettlement();
                 validate();
                 return updated;
             }
@@ -195,10 +200,11 @@ public class Split {
             throw new ParticipantHasExpensesError();
         }
         boolean removed = participants.removeIf(p -> p.id().equals(participantId));
-        validate();
         if (!removed) {
             throw new ParticipantNotFoundError(participantId.value(), id.value());
         }
+        clearSettlement();
+        validate();
     }
 
     /**
@@ -235,6 +241,7 @@ public class Split {
                 Expense updated = Expense.fromJson(expenseId, amount, description, payerId, splitMode,
                         existing.getCreatedAt());
                 expenses.set(i, updated);
+                clearSettlement();
                 validate();
                 return updated;
             }
@@ -256,6 +263,7 @@ public class Split {
         if (!removed) {
             throw new ExpenseNotFoundError(expenseId.value(), id.value());
         }
+        clearSettlement();
         validate();
     }
 
@@ -273,6 +281,21 @@ public class Split {
         if (!exists) {
             throw new PayerNotFoundError(payerId.value(), id.value());
         }
+    }
+
+    /**
+     * Persists a calculated settlement in this split.
+     */
+    public void settle(Settlement settlement) {
+        Objects.requireNonNull(settlement, "Settlement cannot be null");
+        this.settlement = settlement;
+    }
+
+    /**
+     * Clears the persisted settlement. Called automatically when participants or expenses are modified.
+     */
+    public void clearSettlement() {
+        this.settlement = null;
     }
 
     // Getters - return value objects and unmodifiable collections
@@ -295,6 +318,10 @@ public class Split {
 
     public List<Expense> getExpenses() {
         return Collections.unmodifiableList(expenses);
+    }
+
+    public Settlement getSettlement() {
+        return settlement;
     }
 
     /**

--- a/fairnsquare-app/src/main/java/org/asymetrik/web/fairnsquare/split/persistence/dto/SettlementPersistenceDTO.java
+++ b/fairnsquare-app/src/main/java/org/asymetrik/web/fairnsquare/split/persistence/dto/SettlementPersistenceDTO.java
@@ -1,0 +1,19 @@
+package org.asymetrik.web.fairnsquare.split.persistence.dto;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+/**
+ * Persistence DTO for Settlement. Mirrors the JSON storage format with primitive types.
+ */
+public record SettlementPersistenceDTO(List<ParticipantBalancePersistenceDTO> balances,
+        List<ReimbursementPersistenceDTO> reimbursements) {
+
+    public record ParticipantBalancePersistenceDTO(String participantId, String participantName, BigDecimal totalPaid,
+            BigDecimal totalCost, BigDecimal balance) {
+    }
+
+    public record ReimbursementPersistenceDTO(String fromId, String fromName, String toId, String toName,
+            BigDecimal amount) {
+    }
+}

--- a/fairnsquare-app/src/main/java/org/asymetrik/web/fairnsquare/split/persistence/dto/SplitPersistenceDTO.java
+++ b/fairnsquare-app/src/main/java/org/asymetrik/web/fairnsquare/split/persistence/dto/SplitPersistenceDTO.java
@@ -7,5 +7,6 @@ import java.util.List;
  * primitives, createdAt as ISO-8601 string.
  */
 public record SplitPersistenceDTO(String id, String name, String createdAt,
-        List<ParticipantPersistenceDTO> participants, List<ExpensePersistenceDTO> expenses) {
+        List<ParticipantPersistenceDTO> participants, List<ExpensePersistenceDTO> expenses,
+        SettlementPersistenceDTO settlement) {
 }

--- a/fairnsquare-app/src/main/java/org/asymetrik/web/fairnsquare/split/persistence/mapper/SplitPersistenceMapper.java
+++ b/fairnsquare-app/src/main/java/org/asymetrik/web/fairnsquare/split/persistence/mapper/SplitPersistenceMapper.java
@@ -7,8 +7,13 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 
 import org.asymetrik.web.fairnsquare.split.domain.Split;
+import org.asymetrik.web.fairnsquare.split.domain.participant.Participant;
+import org.asymetrik.web.fairnsquare.split.domain.settlement.ParticipantBalance;
+import org.asymetrik.web.fairnsquare.split.domain.settlement.Reimbursement;
+import org.asymetrik.web.fairnsquare.split.domain.settlement.Settlement;
 import org.asymetrik.web.fairnsquare.split.persistence.dto.ExpensePersistenceDTO;
 import org.asymetrik.web.fairnsquare.split.persistence.dto.ParticipantPersistenceDTO;
+import org.asymetrik.web.fairnsquare.split.persistence.dto.SettlementPersistenceDTO;
 import org.asymetrik.web.fairnsquare.split.persistence.dto.SplitPersistenceDTO;
 
 /**
@@ -35,8 +40,10 @@ public class SplitPersistenceMapper {
         List<ExpensePersistenceDTO> expenses = split.getExpenses().stream().map(expenseMapper::toPersistenceDTO)
                 .toList();
 
+        SettlementPersistenceDTO settlementDTO = settlementToPersistenceDTO(split.getSettlement());
+
         return new SplitPersistenceDTO(split.getId().value(), split.getName().value(), split.getCreatedAt().toString(),
-                participants, expenses);
+                participants, expenses, settlementDTO);
     }
 
     public Split toDomain(SplitPersistenceDTO dto) {
@@ -50,6 +57,37 @@ public class SplitPersistenceMapper {
             dto.expenses().forEach(e -> split.addExpense(expenseMapper.toDomain(e)));
         }
 
+        if (dto.settlement() != null) {
+            split.settle(settlementToDomain(dto.settlement()));
+        }
+
         return split;
+    }
+
+    private SettlementPersistenceDTO settlementToPersistenceDTO(Settlement settlement) {
+        if (settlement == null) {
+            return null;
+        }
+        List<SettlementPersistenceDTO.ParticipantBalancePersistenceDTO> balances = settlement.balances().stream()
+                .map(b -> new SettlementPersistenceDTO.ParticipantBalancePersistenceDTO(b.participantId().value(),
+                        b.participantName(), b.totalPaid(), b.totalCost(), b.balance()))
+                .toList();
+        List<SettlementPersistenceDTO.ReimbursementPersistenceDTO> reimbursements = settlement.reimbursements().stream()
+                .map(r -> new SettlementPersistenceDTO.ReimbursementPersistenceDTO(r.fromId().value(), r.fromName(),
+                        r.toId().value(), r.toName(), r.amount()))
+                .toList();
+        return new SettlementPersistenceDTO(balances, reimbursements);
+    }
+
+    private Settlement settlementToDomain(SettlementPersistenceDTO dto) {
+        List<ParticipantBalance> balances = dto.balances().stream()
+                .map(b -> new ParticipantBalance(Participant.Id.of(b.participantId()), b.participantName(),
+                        b.totalPaid(), b.totalCost(), b.balance()))
+                .toList();
+        List<Reimbursement> reimbursements = dto.reimbursements().stream()
+                .map(r -> new Reimbursement(Participant.Id.of(r.fromId()), r.fromName(), Participant.Id.of(r.toId()),
+                        r.toName(), r.amount()))
+                .toList();
+        return new Settlement(balances, reimbursements);
     }
 }

--- a/fairnsquare-app/src/main/java/org/asymetrik/web/fairnsquare/split/service/SplitUseCases.java
+++ b/fairnsquare-app/src/main/java/org/asymetrik/web/fairnsquare/split/service/SplitUseCases.java
@@ -68,7 +68,7 @@ public class SplitUseCases {
     }
 
     /**
-     * Calculates the settlement for a split: participant balances and reimbursement proposals.
+     * Calculates the settlement for a split, persists it in the split, and returns it.
      *
      * @param splitId
      *            the split identifier
@@ -76,7 +76,12 @@ public class SplitUseCases {
      * @return an Optional containing the settlement if the split exists, empty otherwise
      */
     public Optional<Settlement> calculateSettlement(String splitId) {
-        return repository.load(splitId).map(SettlementCalculator::calculate);
+        return repository.load(splitId).map(split -> {
+            Settlement settlement = SettlementCalculator.calculate(split);
+            split.settle(settlement);
+            repository.save(split);
+            return settlement;
+        });
     }
 
     /**

--- a/fairnsquare-app/src/main/webui/src/lib/api/splits.ts
+++ b/fairnsquare-app/src/main/webui/src/lib/api/splits.ts
@@ -72,6 +72,7 @@ export interface Split {
   createdAt: string;
   participants: Participant[];
   expenses: Expense[];
+  settlement: Settlement | null;
 }
 
 export interface ParticipantBalance {

--- a/fairnsquare-app/src/main/webui/src/routes/Settlement.svelte
+++ b/fairnsquare-app/src/main/webui/src/routes/Settlement.svelte
@@ -11,10 +11,18 @@
 
   const splitId = $derived(route.params.splitId || '');
 
+  // Check if we should show resolved view directly (coming from a persisted settlement)
+  function checkInitialResolved(): boolean {
+    if (typeof window === 'undefined') return false;
+    const resolved = sessionStorage.getItem('settlement-resolved') === 'true';
+    sessionStorage.removeItem('settlement-resolved');
+    return resolved;
+  }
+
   // State
   let settlement = $state<Settlement | null>(null);
   let isLoading = $state(true);
-  let showReimbursements = $state(false);
+  let showReimbursements = $state(checkInitialResolved());
 
   // Load settlement data
   $effect(() => {
@@ -26,7 +34,6 @@
   async function loadSettlement(id: string) {
     isLoading = true;
     settlement = null;
-    showReimbursements = false;
 
     try {
       settlement = await getSettlement(id);

--- a/fairnsquare-app/src/main/webui/src/routes/Settlement.test.ts
+++ b/fairnsquare-app/src/main/webui/src/routes/Settlement.test.ts
@@ -287,4 +287,27 @@ describe('Settlement', () => {
     // But after clicking, no reimbursement details appear since the list is empty
     expect(screen.getByRole('button', { name: 'Resolve' })).toBeInTheDocument();
   });
+
+  // --- Auto-resolved via sessionStorage ---
+
+  it('shows reimbursements directly when settlement-resolved flag is set', async () => {
+    // Simulate flag set by Split dashboard
+    sessionStorage.setItem('settlement-resolved', 'true');
+
+    vi.mocked(getSettlement).mockResolvedValue(mockSettlement);
+
+    render(Settlement);
+
+    await waitFor(() => {
+      // Reimbursements should be visible immediately without clicking Resolve
+      expect(screen.getByText('Pay €50.00 to Alice')).toBeInTheDocument();
+      expect(screen.getByText('Receive €50.00 from Bob')).toBeInTheDocument();
+    });
+
+    // Resolve button should not be visible
+    expect(screen.queryByRole('button', { name: 'Resolve' })).not.toBeInTheDocument();
+
+    // Flag should be consumed (removed from sessionStorage)
+    expect(sessionStorage.getItem('settlement-resolved')).toBeNull();
+  });
 });

--- a/fairnsquare-app/src/main/webui/src/routes/Split.svelte
+++ b/fairnsquare-app/src/main/webui/src/routes/Split.svelte
@@ -24,6 +24,9 @@
     split?.expenses.reduce((sum, e) => sum + e.amount, 0) ?? 0
   );
 
+  // Settlement status
+  const isSettled = $derived(split?.settlement != null);
+
   // Participant summary stats
   const participantCount = $derived(split?.participants.length ?? 0);
   const participantSummary = $derived(
@@ -209,7 +212,10 @@
       <section class="w-full">
         <button
           class="w-full text-left"
-          onclick={() => navigate(`/splits/${splitId}/settlement`)}
+          onclick={() => {
+            if (isSettled) sessionStorage.setItem('settlement-resolved', 'true');
+            navigate(`/splits/${splitId}/settlement`);
+          }}
           aria-label="View settlement"
         >
           <Card.Root class="border-teal-200 bg-teal-50/50 hover:bg-teal-50 transition-colors cursor-pointer">
@@ -217,7 +223,7 @@
               <div class="flex items-center justify-between">
                 <div>
                   <p class="text-sm text-muted-foreground">Settlement</p>
-                  <p class="text-lg font-semibold">Solve</p>
+                  <p class="text-lg font-semibold">{isSettled ? 'Settled' : 'Solve'}</p>
                 </div>
                 <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 text-primary" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                   <path stroke-linecap="round" stroke-linejoin="round" d="M9 5l7 7-7 7" />

--- a/fairnsquare-app/src/main/webui/src/routes/Split.test.ts
+++ b/fairnsquare-app/src/main/webui/src/routes/Split.test.ts
@@ -91,6 +91,7 @@ describe('Split', () => {
         createdAt: '2026-01-24T12:00:00Z',
         participants: [],
         expenses: [],
+        settlement: null,
       });
 
     render(Split);
@@ -117,6 +118,7 @@ describe('Split', () => {
       createdAt: '2026-01-24T12:00:00Z',
       participants: [],
       expenses: [],
+      settlement: null,
     };
 
     const mockSplitWithData: SplitType = {
@@ -153,6 +155,7 @@ describe('Split', () => {
           ],
         },
       ],
+      settlement: null,
     };
 
     it('displays split name as header', async () => {
@@ -401,7 +404,7 @@ describe('Split', () => {
       expect(screen.queryByText('Solve')).not.toBeInTheDocument();
     });
 
-    it('navigates to settlement page when Solve card is clicked', async () => {
+    it('navigates to settlement page without query param when not settled', async () => {
       vi.mocked(getSplit).mockResolvedValue(mockSplitWithData);
 
       render(Split);
@@ -413,6 +416,69 @@ describe('Split', () => {
       await fireEvent.click(screen.getByRole('button', { name: 'View settlement' }));
 
       expect(navigate).toHaveBeenCalledWith('/splits/test-split-id/settlement');
+    });
+
+    it('shows "Settled" when settlement is persisted', async () => {
+      const mockSplitSettled: SplitType = {
+        ...mockSplitWithData,
+        settlement: {
+          balances: [
+            { participantId: 'p1', participantName: 'Alice', totalPaid: 90, totalCost: 75, balance: 15 },
+            { participantId: 'p2', participantName: 'Bob', totalPaid: 60, totalCost: 75, balance: -15 },
+          ],
+          reimbursements: [
+            { fromId: 'p2', fromName: 'Bob', toId: 'p1', toName: 'Alice', amount: 15 },
+          ],
+        },
+      };
+      vi.mocked(getSplit).mockResolvedValue(mockSplitSettled);
+
+      render(Split);
+
+      await waitFor(() => {
+        expect(screen.getByText('Settled')).toBeInTheDocument();
+      });
+
+      expect(screen.queryByText('Solve')).not.toBeInTheDocument();
+    });
+
+    it('sets sessionStorage flag and navigates when settlement is persisted', async () => {
+      const mockSplitSettled: SplitType = {
+        ...mockSplitWithData,
+        settlement: {
+          balances: [
+            { participantId: 'p1', participantName: 'Alice', totalPaid: 90, totalCost: 75, balance: 15 },
+            { participantId: 'p2', participantName: 'Bob', totalPaid: 60, totalCost: 75, balance: -15 },
+          ],
+          reimbursements: [
+            { fromId: 'p2', fromName: 'Bob', toId: 'p1', toName: 'Alice', amount: 15 },
+          ],
+        },
+      };
+      vi.mocked(getSplit).mockResolvedValue(mockSplitSettled);
+
+      render(Split);
+
+      await waitFor(() => {
+        expect(screen.getByText('Settled')).toBeInTheDocument();
+      });
+
+      await fireEvent.click(screen.getByRole('button', { name: 'View settlement' }));
+
+      expect(sessionStorage.getItem('settlement-resolved')).toBe('true');
+      expect(navigate).toHaveBeenCalledWith('/splits/test-split-id/settlement');
+    });
+
+    it('shows "Solve" when settlement is null', async () => {
+      vi.mocked(getSplit).mockResolvedValue(mockSplitWithData);
+
+      render(Split);
+
+      await waitFor(() => {
+        expect(screen.getByText('Solve')).toBeInTheDocument();
+      });
+
+      expect(screen.queryByText('Settled')).not.toBeInTheDocument();
     });
   });
 });

--- a/fairnsquare-app/src/test/java/org/asymetrik/web/fairnsquare/split/api/mapper/SplitMapperTest.java
+++ b/fairnsquare-app/src/test/java/org/asymetrik/web/fairnsquare/split/api/mapper/SplitMapperTest.java
@@ -6,7 +6,9 @@ import java.math.BigDecimal;
 
 import org.asymetrik.web.fairnsquare.split.api.dto.SplitResponseDTO;
 import org.asymetrik.web.fairnsquare.split.domain.expenses.ExpenseByNight;
+import org.asymetrik.web.fairnsquare.split.domain.expenses.ExpenseEqual;
 import org.asymetrik.web.fairnsquare.split.domain.participant.Participant;
+import org.asymetrik.web.fairnsquare.split.domain.settlement.SettlementCalculator;
 import org.asymetrik.web.fairnsquare.split.domain.Split;
 
 import io.quarkus.test.junit.QuarkusTest;
@@ -53,5 +55,31 @@ class SplitMapperTest {
     @Test
     void shouldHandleNullInput() {
         assertThatNullPointerException().isThrownBy(() -> mapper.toDTO(null)).withMessage("Split cannot be null");
+    }
+
+    @Test
+    void shouldMapSettlementWhenPresent() {
+        Split split = Split.create("Settled Split");
+        Participant alice = Participant.create("Alice", 3);
+        Participant bob = Participant.create("Bob", 2);
+        split.addParticipant(alice);
+        split.addParticipant(bob);
+        split.addExpense(ExpenseEqual.create(BigDecimal.valueOf(100.00), "Hotel", alice.id()));
+        split.settle(SettlementCalculator.calculate(split));
+
+        SplitResponseDTO dto = mapper.toDTO(split);
+
+        assertThat(dto.settlement()).isNotNull();
+        assertThat(dto.settlement().balances()).hasSize(2);
+        assertThat(dto.settlement().reimbursements()).hasSize(1);
+    }
+
+    @Test
+    void shouldMapNullSettlementWhenNotPresent() {
+        Split split = Split.create("Unsettled Split");
+
+        SplitResponseDTO dto = mapper.toDTO(split);
+
+        assertThat(dto.settlement()).isNull();
     }
 }

--- a/fairnsquare-app/src/test/java/org/asymetrik/web/fairnsquare/split/domain/SplitSettlementTest.java
+++ b/fairnsquare-app/src/test/java/org/asymetrik/web/fairnsquare/split/domain/SplitSettlementTest.java
@@ -1,0 +1,139 @@
+package org.asymetrik.web.fairnsquare.split.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import org.asymetrik.web.fairnsquare.split.domain.expenses.ExpenseByNight;
+import org.asymetrik.web.fairnsquare.split.domain.expenses.ExpenseEqual;
+import org.asymetrik.web.fairnsquare.split.domain.expenses.SplitMode;
+import org.asymetrik.web.fairnsquare.split.domain.participant.Participant;
+import org.asymetrik.web.fairnsquare.split.domain.settlement.ParticipantBalance;
+import org.asymetrik.web.fairnsquare.split.domain.settlement.Reimbursement;
+import org.asymetrik.web.fairnsquare.split.domain.settlement.Settlement;
+import org.asymetrik.web.fairnsquare.split.domain.settlement.SettlementCalculator;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for Settlement persistence in Split aggregate: settle, getSettlement, and clearSettlement on mutations.
+ */
+class SplitSettlementTest {
+
+    @Test
+    void settle_storesSettlement() {
+        Split split = createSplitWithParticipantsAndExpense();
+        Settlement settlement = SettlementCalculator.calculate(split);
+
+        split.settle(settlement);
+
+        assertThat(split.getSettlement()).isNotNull();
+        assertThat(split.getSettlement()).isSameAs(settlement);
+    }
+
+    @Test
+    void getSettlement_returnsNullByDefault() {
+        Split split = Split.create("Test");
+
+        assertThat(split.getSettlement()).isNull();
+    }
+
+    @Test
+    void clearSettlement_removesSettlement() {
+        Split split = createSplitWithParticipantsAndExpense();
+        split.settle(SettlementCalculator.calculate(split));
+        assertThat(split.getSettlement()).isNotNull();
+
+        split.clearSettlement();
+
+        assertThat(split.getSettlement()).isNull();
+    }
+
+    // --- clearSettlement on mutations ---
+
+    @Test
+    void addParticipant_clearsSettlement() {
+        Split split = createSplitWithParticipantsAndExpense();
+        split.settle(SettlementCalculator.calculate(split));
+        assertThat(split.getSettlement()).isNotNull();
+
+        split.addParticipant(Participant.create("Charlie", 2));
+
+        assertThat(split.getSettlement()).isNull();
+    }
+
+    @Test
+    void updateParticipant_clearsSettlement() {
+        Split split = createSplitWithParticipantsAndExpense();
+        Participant alice = split.getParticipants().get(0);
+        split.settle(SettlementCalculator.calculate(split));
+        assertThat(split.getSettlement()).isNotNull();
+
+        split.updateParticipant(alice.id(), "Alice Updated", 5);
+
+        assertThat(split.getSettlement()).isNull();
+    }
+
+    @Test
+    void removeParticipant_clearsSettlement() {
+        Split split = Split.create("Test");
+        Participant alice = Participant.create("Alice", 3);
+        Participant bob = Participant.create("Bob", 2);
+        split.addParticipant(alice);
+        split.addParticipant(bob);
+        // Add expense paid by Alice only so Bob can be removed
+        split.addExpense(ExpenseEqual.create(new BigDecimal("100.00"), "Dinner", alice.id()));
+        split.settle(SettlementCalculator.calculate(split));
+        assertThat(split.getSettlement()).isNotNull();
+
+        // Bob has no expenses as payer, so can be removed
+        split.removeParticipant(bob.id());
+
+        assertThat(split.getSettlement()).isNull();
+    }
+
+    @Test
+    void addExpense_clearsSettlement() {
+        Split split = createSplitWithParticipantsAndExpense();
+        split.settle(SettlementCalculator.calculate(split));
+        assertThat(split.getSettlement()).isNotNull();
+
+        Participant alice = split.getParticipants().get(0);
+        split.addExpense(ExpenseEqual.create(new BigDecimal("50.00"), "Lunch", alice.id()));
+
+        assertThat(split.getSettlement()).isNull();
+    }
+
+    @Test
+    void updateExpense_clearsSettlement() {
+        Split split = createSplitWithParticipantsAndExpense();
+        split.settle(SettlementCalculator.calculate(split));
+        assertThat(split.getSettlement()).isNotNull();
+
+        split.updateExpense(split.getExpenses().get(0).getId(), new BigDecimal("200.00"), "Updated Hotel",
+                split.getParticipants().get(0).id(), SplitMode.EQUAL);
+
+        assertThat(split.getSettlement()).isNull();
+    }
+
+    @Test
+    void removeExpense_clearsSettlement() {
+        Split split = createSplitWithParticipantsAndExpense();
+        split.settle(SettlementCalculator.calculate(split));
+        assertThat(split.getSettlement()).isNotNull();
+
+        split.removeExpense(split.getExpenses().get(0).getId());
+
+        assertThat(split.getSettlement()).isNull();
+    }
+
+    private Split createSplitWithParticipantsAndExpense() {
+        Split split = Split.create("Test Split");
+        Participant alice = Participant.create("Alice", 3);
+        Participant bob = Participant.create("Bob", 2);
+        split.addParticipant(alice);
+        split.addParticipant(bob);
+        split.addExpense(ExpenseEqual.create(new BigDecimal("100.00"), "Hotel", alice.id()));
+        return split;
+    }
+}

--- a/fairnsquare-app/src/test/java/org/asymetrik/web/fairnsquare/split/persistence/mapper/SplitPersistenceMapperTest.java
+++ b/fairnsquare-app/src/test/java/org/asymetrik/web/fairnsquare/split/persistence/mapper/SplitPersistenceMapperTest.java
@@ -10,6 +10,7 @@ import jakarta.inject.Inject;
 import org.asymetrik.web.fairnsquare.split.domain.expenses.ExpenseByNight;
 import org.asymetrik.web.fairnsquare.split.domain.expenses.ExpenseEqual;
 import org.asymetrik.web.fairnsquare.split.domain.participant.Participant;
+import org.asymetrik.web.fairnsquare.split.domain.settlement.SettlementCalculator;
 import org.asymetrik.web.fairnsquare.split.domain.Split;
 import org.asymetrik.web.fairnsquare.split.persistence.dto.ExpenseByNightPersistenceDTO;
 import org.asymetrik.web.fairnsquare.split.persistence.dto.ExpenseEqualPersistenceDTO;
@@ -45,7 +46,7 @@ class SplitPersistenceMapperTest {
     void shouldMapPersistenceDTOToDomain() {
         SplitPersistenceDTO dto = new SplitPersistenceDTO(Split.Id.generate().value(), "Beach House",
                 "2026-01-30T10:00:00Z",
-                List.of(new ParticipantPersistenceDTO(Participant.Id.generate().value(), "Bob", 5)), List.of());
+                List.of(new ParticipantPersistenceDTO(Participant.Id.generate().value(), "Bob", 5)), List.of(), null);
 
         Split split = mapper.toDomain(dto);
 
@@ -119,11 +120,44 @@ class SplitPersistenceMapperTest {
     @Test
     void shouldMapDTOWithNullCollections() {
         SplitPersistenceDTO dto = new SplitPersistenceDTO(Split.Id.generate().value(), "Null Collections",
-                "2026-01-30T10:00:00Z", null, null);
+                "2026-01-30T10:00:00Z", null, null, null);
 
         Split split = mapper.toDomain(dto);
 
         assertThat(split.getParticipants()).isEmpty();
         assertThat(split.getExpenses()).isEmpty();
+    }
+
+    @Test
+    void shouldMapSettlementInRoundTrip() {
+        Split original = Split.create("Settlement Round Trip");
+        Participant alice = Participant.create("Alice", 3);
+        Participant bob = Participant.create("Bob", 2);
+        original.addParticipant(alice);
+        original.addParticipant(bob);
+        original.addExpense(ExpenseEqual.create(new BigDecimal("100.00"), "Hotel", alice.id()));
+        original.settle(SettlementCalculator.calculate(original));
+
+        SplitPersistenceDTO dto = mapper.toPersistenceDTO(original);
+        Split roundTrip = mapper.toDomain(dto);
+
+        assertThat(roundTrip.getSettlement()).isNotNull();
+        assertThat(roundTrip.getSettlement().balances()).hasSize(2);
+        assertThat(roundTrip.getSettlement().reimbursements()).hasSize(1);
+        assertThat(roundTrip.getSettlement().balances().get(0).participantName()).isEqualTo("Alice");
+        assertThat(roundTrip.getSettlement().reimbursements().get(0).fromName()).isEqualTo("Bob");
+        assertThat(roundTrip.getSettlement().reimbursements().get(0).toName()).isEqualTo("Alice");
+        assertThat(roundTrip.getSettlement().reimbursements().get(0).amount()).isEqualByComparingTo("50.00");
+    }
+
+    @Test
+    void shouldMapNullSettlementInRoundTrip() {
+        Split original = Split.create("No Settlement");
+        original.addParticipant(Participant.create("Alice", 3));
+
+        SplitPersistenceDTO dto = mapper.toPersistenceDTO(original);
+        Split roundTrip = mapper.toDomain(dto);
+
+        assertThat(roundTrip.getSettlement()).isNull();
     }
 }

--- a/src/doc/rules/backend-rules.md
+++ b/src/doc/rules/backend-rules.md
@@ -1,0 +1,5 @@
+# Backend Development Rules
+
+## Domain Model
+
+- In mutation methods on aggregate roots, `validate()` must always be the last method call. Any side effects (e.g. `clearSettlement()`) must happen before validation.

--- a/src/main/doc/implementation/2026-02-13-Feature-persist-settlement.md
+++ b/src/main/doc/implementation/2026-02-13-Feature-persist-settlement.md
@@ -1,0 +1,69 @@
+# Feature: Persist Settlement
+
+## What, Why and Constraints
+
+**What**: The settlement (balances and reimbursement proposals) is now persisted in the Split aggregate. When the settlement endpoint is called, the backend calculates the settlement, stores it in the Split, and saves to disk. The Split API response now includes the settlement if present. Any modification to participants or expenses automatically clears the persisted settlement.
+
+**Why**: Users can leave the application and come back later to see their settlement results without recalculating. The dashboard also indicates whether a split has been settled.
+
+**Constraints**:
+- Rich domain model pattern preserved — `settle()` and `clearSettlement()` are behavior methods on the Split aggregate
+- `validate()` remains the last call in all mutation methods
+- Backward compatible with existing JSON files (settlement field is nullable, missing field deserializes as `null`)
+- No new API endpoints — existing `GET /settlement` now also persists; `GET /splits/{splitId}` now includes settlement in response
+
+## How
+
+### Step 1: Domain model (`Split.java`)
+- Added `Settlement settlement` field (nullable)
+- Added `settle(Settlement)` method to store a calculated settlement
+- Added `clearSettlement()` method to clear it
+- Added `getSettlement()` getter
+- All 6 mutation methods (`addParticipant`, `updateParticipant`, `removeParticipant`, `addExpense`, `updateExpense`, `removeExpense`) call `clearSettlement()` before `validate()`
+
+### Step 2: Persistence DTO (`SettlementPersistenceDTO.java`, `SplitPersistenceDTO.java`)
+- Created `SettlementPersistenceDTO` with nested `ParticipantBalancePersistenceDTO` and `ReimbursementPersistenceDTO`
+- Added nullable `settlement` field to `SplitPersistenceDTO`
+
+### Step 3: Persistence mapper (`SplitPersistenceMapper.java`)
+- Added `settlementToPersistenceDTO()` and `settlementToDomain()` private helpers
+- `toPersistenceDTO()` maps settlement (null-safe)
+- `toDomain()` restores settlement via `split.settle()` after participants/expenses are loaded
+
+### Step 4: Service layer (`SplitUseCases.java`)
+- `calculateSettlement()` now: loads split, calculates, calls `split.settle()`, saves, returns settlement
+
+### Step 5: API layer (`SplitResponseDTO.java`, `SplitMapper.java`)
+- Added nullable `settlement` field (reuses `SettlementResponseDTO`) to `SplitResponseDTO`
+- `SplitMapper` injects `SettlementMapper` and maps settlement to DTO
+
+### Step 6: Frontend
+- `splits.ts`: Added `settlement: Settlement | null` to `Split` interface
+- `Split.svelte`: Added `isSettled` derived flag; Solve card shows "Settled" vs "Solve"; sets `sessionStorage` flag when navigating to settlement page while settled
+- `Settlement.svelte`: Reads `sessionStorage` flag on init to auto-show reimbursements (resolved view) when coming from a settled split
+
+## Tests
+
+### Backend (13 new tests)
+
+**`SplitSettlementTest.java`** — 9 tests:
+- `settle_storesSettlement`, `getSettlement_returnsNullByDefault`, `clearSettlement_removesSettlement`
+- Settlement cleared on: `addParticipant`, `updateParticipant`, `removeParticipant`, `addExpense`, `updateExpense`, `removeExpense`
+
+**`SplitPersistenceMapperTest.java`** — 2 new tests:
+- `shouldMapSettlementInRoundTrip` (with settlement data)
+- `shouldMapNullSettlementInRoundTrip`
+
+**`SplitMapperTest.java`** — 2 new tests:
+- `shouldMapSettlementWhenPresent`
+- `shouldMapNullSettlementWhenNotPresent`
+
+### Frontend (4 new tests)
+
+**`Split.test.ts`** — 3 new tests:
+- Shows "Settled" when settlement is persisted
+- Sets sessionStorage flag and navigates when settlement is persisted
+- Shows "Solve" when settlement is null
+
+**`Settlement.test.ts`** — 1 new test:
+- Shows reimbursements directly when settlement-resolved flag is set in sessionStorage


### PR DESCRIPTION
Settlement is now calculated and stored in the Split when the settlement endpoint is called. Any participant or expense mutation automatically clears it. The dashboard shows "Settled" status and navigates directly to the resolved view.