### PR TITLE
fix: add Toaster component to render toast notifications (#49)

### DIFF
--- a/fairnsquare-app/src/main/webui/src/App.svelte
+++ b/fairnsquare-app/src/main/webui/src/App.svelte
@@ -5,6 +5,7 @@
   import { Router } from 'sv-router';
   // Import router config to initialize routes
   import '$lib/router';
+  import Toaster from '$lib/components/ui/toast/Toaster.svelte';
 </script>
 
 <main class="min-h-screen bg-background">
@@ -12,3 +13,4 @@
     <Router />
   </div>
 </main>
+<Toaster />

--- a/fairnsquare-app/src/main/webui/src/lib/components/ui/toast/Toaster.svelte
+++ b/fairnsquare-app/src/main/webui/src/lib/components/ui/toast/Toaster.svelte
@@ -1,0 +1,39 @@
+<script lang="ts">
+  import { getToasts, removeToast } from '$lib/stores/toastStore.svelte';
+
+  const typeStyles: Record<string, string> = {
+    success: 'bg-green-600 text-white',
+    error: 'bg-destructive text-white',
+    warning: 'bg-yellow-500 text-white',
+    info: 'bg-primary text-primary-foreground',
+  };
+
+  const typeIcons: Record<string, string> = {
+    success: '✓',
+    error: '✕',
+    warning: '⚠',
+    info: 'ℹ',
+  };
+</script>
+
+<!-- Fixed bottom-right toast container -->
+<div
+  class="fixed bottom-4 right-4 z-50 flex flex-col gap-2 w-80 max-w-[calc(100vw-2rem)]"
+  aria-live="polite"
+  aria-atomic="false"
+>
+  {#each getToasts() as toast (toast.id)}
+    <div
+      class="flex items-start gap-3 rounded-lg px-4 py-3 shadow-lg {typeStyles[toast.type] ?? typeStyles.info}"
+      role="alert"
+    >
+      <span class="shrink-0 font-bold text-sm mt-0.5">{typeIcons[toast.type] ?? typeIcons.info}</span>
+      <p class="flex-1 text-sm">{toast.message}</p>
+      <button
+        onclick={() => removeToast(toast.id)}
+        class="shrink-0 opacity-70 hover:opacity-100 transition-opacity text-sm font-bold leading-none"
+        aria-label="Dismiss"
+      >✕</button>
+    </div>
+  {/each}
+</div>

--- a/fairnsquare-app/src/main/webui/src/lib/components/ui/toast/Toaster.test.ts
+++ b/fairnsquare-app/src/main/webui/src/lib/components/ui/toast/Toaster.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/svelte';
+import Toaster from './Toaster.svelte';
+import { addToast, clearToasts } from '$lib/stores/toastStore.svelte';
+
+describe('Toaster', () => {
+  beforeEach(() => {
+    clearToasts();
+  });
+
+  it('renders nothing when there are no toasts', () => {
+    render(Toaster);
+
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  it('renders a toast message when addToast is called', async () => {
+    render(Toaster);
+    addToast({ type: 'success', message: 'Saved successfully!' });
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toBeInTheDocument();
+      expect(screen.getByText('Saved successfully!')).toBeInTheDocument();
+    });
+  });
+
+  it('renders multiple toasts', async () => {
+    render(Toaster);
+    addToast({ type: 'success', message: 'First toast' });
+    addToast({ type: 'error', message: 'Second toast' });
+
+    await waitFor(() => {
+      expect(screen.getAllByRole('alert')).toHaveLength(2);
+      expect(screen.getByText('First toast')).toBeInTheDocument();
+      expect(screen.getByText('Second toast')).toBeInTheDocument();
+    });
+  });
+
+  it('shows a dismiss button on each toast', async () => {
+    render(Toaster);
+    addToast({ type: 'info', message: 'Hello' });
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Dismiss' })).toBeInTheDocument();
+    });
+  });
+
+  it('removes toast when dismiss button is clicked', async () => {
+    render(Toaster);
+    addToast({ type: 'info', message: 'Dismiss me' });
+
+    await waitFor(() => {
+      expect(screen.getByText('Dismiss me')).toBeInTheDocument();
+    });
+
+    await fireEvent.click(screen.getByRole('button', { name: 'Dismiss' }));
+
+    await waitFor(() => {
+      expect(screen.queryByText('Dismiss me')).not.toBeInTheDocument();
+    });
+  });
+
+  it('applies success styles for type success', async () => {
+    render(Toaster);
+    addToast({ type: 'success', message: 'Done!' });
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert').className).toContain('bg-green-600');
+    });
+  });
+
+  it('applies error styles for type error', async () => {
+    render(Toaster);
+    addToast({ type: 'error', message: 'Oops!' });
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert').className).toContain('bg-destructive');
+    });
+  });
+
+  it('applies warning styles for type warning', async () => {
+    render(Toaster);
+    addToast({ type: 'warning', message: 'Watch out!' });
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert').className).toContain('bg-yellow-500');
+    });
+  });
+
+  it('applies info styles for type info', async () => {
+    render(Toaster);
+    addToast({ type: 'info', message: 'FYI' });
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert').className).toContain('bg-primary');
+    });
+  });
+
+  it('has aria-live polite on the container', () => {
+    const { container } = render(Toaster);
+
+    expect(container.querySelector('[aria-live="polite"]')).toBeInTheDocument();
+  });
+});

--- a/src/doc/rules/frontend-rules.md
+++ b/src/doc/rules/frontend-rules.md
@@ -15,6 +15,10 @@
 - Forms that create or update entities must include client-side validation that mirrors backend constraints (e.g. uniqueness, format, range). Do not rely solely on API error responses and toast notifications for user feedback — use inline form errors.
 - Inline validation while typing must not show "required" errors on an empty field — that error is reserved for form submission. Other errors (format, range, uniqueness) must appear as soon as the invalid value is detected while typing.
 
+## Testing Reactive Store Updates
+
+- When a reactive store is mutated (e.g. `addToast()`, `clearToasts()`) after `render()` in a test, always wrap assertions in `waitFor()`. Svelte 5's DOM updates are batched and asynchronous from the test runner's perspective — synchronous assertions after store mutations will see stale DOM.
+
 ## Testing Number Inputs
 
 - For `<input type="number">` with Svelte's `bind:value`, always use `fireEvent.input(el, { target: { value: '...' } })` instead of `userEvent.clear()` + `userEvent.type()`. The `userEvent` approach does not reliably trigger Svelte's `bind:value` reactivity for number inputs in jsdom. Use `fireEvent.blur()` to trigger `onblur` validation handlers.

--- a/src/main/doc/implementation/2026-02-26-Bugfix-Toast-Not-Visible.md
+++ b/src/main/doc/implementation/2026-02-26-Bugfix-Toast-Not-Visible.md
@@ -1,0 +1,63 @@
+# Bugfix: Toast Notifications Not Visible
+
+**Date:** 2026-02-26
+**Issue:** [#49](https://github.com/fblan/fairnsquare/issues/49)
+**Branch:** `bugfix/49-toast-not-visible`
+
+---
+
+## 1. What, Why and Constraints
+
+**What:** Toast notifications were never displayed in the UI despite `addToast()` being called throughout the application (on errors, success actions, redirects, etc.).
+
+**Why:** The `toastStore.svelte.ts` store correctly manages toast state using Svelte 5 `$state` runes, and `addToast` / `removeToast` were already wired up across all route components. However, no component ever read from the store and rendered the toasts into the DOM. `App.svelte` only mounted the `<Router />` — there was no `<Toaster />` component anywhere in the component tree.
+
+**Constraints:**
+- The `Toaster` must be mounted outside the `<main>` content container so it is not clipped by `overflow` or constrained by `max-width`.
+- It must use `aria-live="polite"` for accessibility.
+- Styling must follow the existing Tailwind/shadcn design system (destructive, primary, green-600, yellow-500).
+- Every frontend change must be covered by automated tests.
+
+---
+
+## 2. How
+
+### Files created
+
+**`fairnsquare-app/src/main/webui/src/lib/components/ui/toast/Toaster.svelte`**
+
+- New component that calls `getToasts()` from the store reactively inside an `{#each}` block.
+- Renders a fixed bottom-right container (`z-50`) with one `role="alert"` div per toast.
+- Each toast is colour-coded by type: success (green-600), error (destructive), warning (yellow-500), info (primary).
+- Each toast has a dismiss button that calls `removeToast(toast.id)`.
+- The container has `aria-live="polite"` and `aria-atomic="false"` for screen reader support.
+
+**`fairnsquare-app/src/main/webui/src/lib/components/ui/toast/Toaster.test.ts`**
+
+- 10 automated tests covering all behaviour of the `Toaster` component (see Tests section).
+
+### Files modified
+
+**`fairnsquare-app/src/main/webui/src/App.svelte`**
+
+- Imported `Toaster` and added `<Toaster />` after the closing `</main>` tag, so it sits at the root of the document, unrestricted by the content container's max-width or padding.
+
+---
+
+## 3. Tests
+
+**File:** `src/lib/components/ui/toast/Toaster.test.ts`
+**Total tests:** 10 (all passing)
+
+| Test | What it covers |
+|---|---|
+| renders nothing when there are no toasts | Empty state — container present but no alerts |
+| renders a toast message when addToast is called | Single toast rendered after store update |
+| renders multiple toasts | Multiple toasts from multiple `addToast` calls |
+| shows a dismiss button on each toast | Dismiss button accessibility |
+| removes toast when dismiss button is clicked | `removeToast` wired to button click |
+| applies success styles for type success | `bg-green-600` class present |
+| applies error styles for type error | `bg-destructive` class present |
+| applies warning styles for type warning | `bg-yellow-500` class present |
+| applies info styles for type info | `bg-primary` class present |
+| has aria-live polite on the container | Accessibility attribute on container |


### PR DESCRIPTION
## Summary

- Toast notifications were never displayed despite `addToast()` being called throughout the app — the toast store existed but no component rendered its state into the DOM
- Created `Toaster.svelte`: fixed bottom-right container, colour-coded by type (success/error/warning/info), dismiss button, `aria-live="polite"` for accessibility
- Mounted `<Toaster />` in `App.svelte` outside the `<main>` content container so it is never clipped or width-constrained
- Added a new frontend rule: always use `waitFor()` when asserting on reactive store mutations in tests

## Test plan

- [x] `Toaster.test.ts` — 10 tests passing (empty state, single/multiple toasts, dismiss, type styles, aria-live)
- [x] Manual: toasts now appear bottom-right on redirect, share link copy, errors, etc.

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)