### PR TITLE
fix: sort debtors/creditors by amount desc for deterministic settlement (#46)

### DIFF
--- a/fairnsquare-app/src/main/java/org/asymetrik/web/fairnsquare/split/domain/settlement/SettlementCalculator.java
+++ b/fairnsquare-app/src/main/java/org/asymetrik/web/fairnsquare/split/domain/settlement/SettlementCalculator.java
@@ -12,7 +12,8 @@ import org.asymetrik.web.fairnsquare.split.domain.participant.Participant;
 
 /**
  * Computes settlement for a split: calculates per-participant balances and proposes reimbursement transfers using a
- * naive greedy algorithm.
+ * greedy min-cash-flow algorithm that sorts debtors and creditors by amount descending to produce deterministic,
+ * intuitive results regardless of participant insertion order.
  */
 public class SettlementCalculator {
 
@@ -70,8 +71,9 @@ public class SettlementCalculator {
     }
 
     /**
-     * Naive greedy algorithm: matches debtors with creditors by transferring the minimum of each pair's remaining
-     * amount until all debts are settled.
+     * Greedy min-cash-flow algorithm: sorts debtors (largest debt first) and creditors (largest credit first), then
+     * matches them with a two-pointer approach, transferring the minimum of each pair's remaining amount until all
+     * debts are settled. Sorting makes results deterministic and independent of participant insertion order.
      */
     private static List<Reimbursement> calculateReimbursements(List<ParticipantBalance> balances) {
         // Separate into debtors (balance < 0) and creditors (balance > 0)
@@ -90,6 +92,10 @@ public class SettlementCalculator {
                 creditRemaining.add(pb.balance());
             }
         }
+
+        // Sort largest debt/credit first for deterministic, intuitive results
+        sortByAmountDescending(debtors, debtRemaining);
+        sortByAmountDescending(creditors, creditRemaining);
 
         List<Reimbursement> reimbursements = new ArrayList<>();
         int d = 0;
@@ -116,5 +122,24 @@ public class SettlementCalculator {
         }
 
         return reimbursements;
+    }
+
+    /**
+     * Sorts participants and their corresponding remaining-amount list together by amount descending.
+     */
+    private static void sortByAmountDescending(List<ParticipantBalance> participants, List<BigDecimal> amounts) {
+        int n = participants.size();
+        for (int i = 0; i < n - 1; i++) {
+            for (int j = i + 1; j < n; j++) {
+                if (amounts.get(j).compareTo(amounts.get(i)) > 0) {
+                    ParticipantBalance tmpP = participants.get(i);
+                    participants.set(i, participants.get(j));
+                    participants.set(j, tmpP);
+                    BigDecimal tmpA = amounts.get(i);
+                    amounts.set(i, amounts.get(j));
+                    amounts.set(j, tmpA);
+                }
+            }
+        }
     }
 }

--- a/fairnsquare-app/src/test/java/org/asymetrik/web/fairnsquare/split/domain/settlement/SettlementCalculatorTest.java
+++ b/fairnsquare-app/src/test/java/org/asymetrik/web/fairnsquare/split/domain/settlement/SettlementCalculatorTest.java
@@ -246,6 +246,102 @@ class SettlementCalculatorTest {
         assertThat(settlement.balances().get(2).participantId()).isEqualTo(bob.id());
     }
 
+    @Test
+    void calculate_largestDebtSettledFirst_regardlessOfInsertionOrder() {
+        // Alice owes €10, Bob owes €2 — inserted in that order.
+        // Charlie is owed €7, Dave is owed €5 — inserted in that order.
+        // With sorting: largest debtor (Alice -10) pays largest creditor (Charlie +7) first,
+        // then Alice pays Dave €3, then Bob pays Dave €2.
+        // Without sorting: Alice would pay Charlie first too in this case, but if insertion
+        // order were reversed (Bob before Alice), the naive algorithm would give different results.
+        Split splitNaturalOrder = createSplit();
+        Participant alice = Participant.create("Alice", 1);
+        Participant bob = Participant.create("Bob", 1);
+        Participant charlie = Participant.create("Charlie", 1);
+        Participant dave = Participant.create("Dave", 1);
+        splitNaturalOrder.addParticipant(alice);
+        splitNaturalOrder.addParticipant(bob);
+        splitNaturalOrder.addParticipant(charlie);
+        splitNaturalOrder.addParticipant(dave);
+
+        // Alice pays €2 of a €12 total → balance -10
+        splitNaturalOrder.addExpense(ExpenseEqual.create(new BigDecimal("12.00"), "Hotel", charlie.id()));
+        splitNaturalOrder.addExpense(ExpenseEqual.create(new BigDecimal("12.00"), "Dinner", dave.id()));
+        // Each owes €6 per expense → total cost per person €12
+        // Alice paid 0, Bob paid 0, Charlie paid 12, Dave paid 12
+        // Alice: cost 12, paid 0, balance -12 (but we want -10 and -2 — use different amounts)
+
+        // Let's build the scenario directly: use 3 expenses to get precise balances
+        // Reset with a clean split
+        Split split = createSplit();
+        Participant a = Participant.create("Alice", 1); // will owe €10
+        Participant b = Participant.create("Bob", 1); // will owe €2
+        Participant c = Participant.create("Charlie", 1); // will be owed €7
+        Participant d = Participant.create("Dave", 1); // will be owed €5
+        split.addParticipant(a);
+        split.addParticipant(b);
+        split.addParticipant(c);
+        split.addParticipant(d);
+
+        // Total expenses = 48: each owes 12.
+        // Charlie pays 19 → balance +7. Dave pays 17 → balance +5.
+        // Alice pays 2 → balance -10. Bob pays 10 → balance -2.
+        split.addExpense(ExpenseEqual.create(new BigDecimal("19.00"), "Groceries", c.id()));
+        split.addExpense(ExpenseEqual.create(new BigDecimal("17.00"), "Gas", d.id()));
+        split.addExpense(ExpenseEqual.create(new BigDecimal("2.00"), "Coffee", a.id()));
+        split.addExpense(ExpenseEqual.create(new BigDecimal("10.00"), "Snacks", b.id()));
+
+        Settlement settlement = SettlementCalculator.calculate(split);
+
+        // Sorted: debtors [Alice(-10), Bob(-2)], creditors [Charlie(+7), Dave(+5)]
+        // Alice → Charlie 7 (Charlie done, Alice has 3 left)
+        // Alice → Dave 3 (Dave has 2 left, Alice done)
+        // Bob → Dave 2 (Dave done, Bob done)
+        assertThat(settlement.reimbursements()).hasSize(3);
+        assertThat(settlement.reimbursements().get(0).fromId()).isEqualTo(a.id());
+        assertThat(settlement.reimbursements().get(0).toId()).isEqualTo(c.id());
+        assertThat(settlement.reimbursements().get(0).amount()).isEqualByComparingTo("7.00");
+
+        assertThat(settlement.reimbursements().get(1).fromId()).isEqualTo(a.id());
+        assertThat(settlement.reimbursements().get(1).toId()).isEqualTo(d.id());
+        assertThat(settlement.reimbursements().get(1).amount()).isEqualByComparingTo("3.00");
+
+        assertThat(settlement.reimbursements().get(2).fromId()).isEqualTo(b.id());
+        assertThat(settlement.reimbursements().get(2).toId()).isEqualTo(d.id());
+        assertThat(settlement.reimbursements().get(2).amount()).isEqualByComparingTo("2.00");
+    }
+
+    @Test
+    void calculate_sortingIsDeterministic_regardlessOfInsertionOrder() {
+        // Same balances as above but participants added in reverse order.
+        // Without sorting the reimbursements would differ; with sorting they must be identical.
+        Split split = createSplit();
+        Participant b = Participant.create("Bob", 1); // will owe €2
+        Participant a = Participant.create("Alice", 1); // will owe €10
+        Participant d = Participant.create("Dave", 1); // will be owed €5
+        Participant c = Participant.create("Charlie", 1); // will be owed €7
+        split.addParticipant(b);
+        split.addParticipant(a);
+        split.addParticipant(d);
+        split.addParticipant(c);
+
+        split.addExpense(ExpenseEqual.create(new BigDecimal("19.00"), "Groceries", c.id()));
+        split.addExpense(ExpenseEqual.create(new BigDecimal("17.00"), "Gas", d.id()));
+        split.addExpense(ExpenseEqual.create(new BigDecimal("2.00"), "Coffee", a.id()));
+        split.addExpense(ExpenseEqual.create(new BigDecimal("10.00"), "Snacks", b.id()));
+
+        Settlement settlement = SettlementCalculator.calculate(split);
+
+        // Regardless of insertion order, sorting ensures:
+        // largest debtor (Alice -10) pays largest creditor (Charlie +7) first
+        assertThat(settlement.reimbursements()).hasSize(3);
+
+        Reimbursement first = settlement.reimbursements().get(0);
+        assertThat(first.amount()).isEqualByComparingTo("7.00"); // largest single transaction first
+        assertThat(first.toId()).isEqualTo(c.id()); // largest creditor (Charlie +7) paid first
+        assertThat(first.fromId()).isEqualTo(a.id()); // largest debtor (Alice -10) pays first
+    }
+
     private Split createSplit() {
         return Split.create("Test Split");
     }

--- a/src/main/doc/implementation/2026-02-26-Bugfix-Min-Cash-Flow-Settlement-Algorithm.md
+++ b/src/main/doc/implementation/2026-02-26-Bugfix-Min-Cash-Flow-Settlement-Algorithm.md
@@ -1,0 +1,53 @@
+# Bugfix: Better Settlement Algorithm (Min Cash Flow)
+
+**Date:** 2026-02-26
+**Issue:** [#46](https://github.com/fblan/fairnsquare/issues/46)
+**Branch:** `bugfix/46-min-cash-flow-settlement`
+
+---
+
+## 1. What, Why and Constraints
+
+**What:** Replaced the naive greedy settlement algorithm with a sorted greedy (min cash flow) algorithm in `SettlementCalculator.java`. The balance calculation (`calculateBalances`) is unchanged and correct.
+
+**Why:** The previous algorithm matched debtors to creditors in participant insertion order. This meant:
+- The same group of people with the same expenses could produce different reimbursement sequences depending on who was added to the split first — non-deterministic from the user's perspective.
+- Smaller debts could be settled before larger ones, producing a less intuitive presentation (largest amounts should appear first).
+
+The fix sorts debtors by absolute balance descending and creditors by balance descending before the two-pointer matching loop. This ensures:
+- **Determinism**: the same net balances always produce the same reimbursements, regardless of insertion order.
+- **Clarity**: largest transactions appear first, making the settlement easier to read and act on.
+- **Minimal splits**: large amounts cancel each other cleanly before small remainders are distributed.
+
+**Constraints:**
+- Only the reimbursement calculation is changed. Balance calculation (totalPaid, totalCost, balance per participant) is correct and untouched.
+- `BigDecimal` arithmetic is preserved throughout for financial precision.
+- The sort is implemented as a simple in-place swap loop (no external sort utility needed) to keep the parallel `participants`/`amounts` lists in sync.
+
+---
+
+## 2. How
+
+### Files modified
+
+**`fairnsquare-app/src/main/java/org/asymetrik/web/fairnsquare/split/domain/settlement/SettlementCalculator.java`**
+
+- Added `sortByAmountDescending(List<ParticipantBalance>, List<BigDecimal>)` private helper that co-sorts both parallel lists (participants and their remaining amounts) using a simple selection-sort swap.
+- In `calculateReimbursements()`, called `sortByAmountDescending` on both `debtors`/`debtRemaining` and `creditors`/`creditRemaining` before the two-pointer matching loop.
+- Updated Javadoc on the class and on `calculateReimbursements()` to reflect the new algorithm description.
+
+**`fairnsquare-app/src/test/java/org/asymetrik/web/fairnsquare/split/domain/settlement/SettlementCalculatorTest.java`**
+
+- Added 2 new tests demonstrating the sorting behaviour (see Tests section).
+
+---
+
+## 3. Tests
+
+**File:** `src/test/java/.../settlement/SettlementCalculatorTest.java`
+**Total tests:** 12 (all passing, 10 pre-existing + 2 new)
+
+| Test | What it covers |
+|---|---|
+| `calculate_largestDebtSettledFirst_regardlessOfInsertionOrder` | 4-participant scenario (Alice -10, Bob -2, Charlie +7, Dave +5): verifies sorted order produces Alice→Charlie €7, Alice→Dave €3, Bob→Dave €2 |
+| `calculate_sortingIsDeterministic_regardlessOfInsertionOrder` | Same balances with reversed insertion order (Bob, Alice, Dave, Charlie): verifies the first reimbursement is still Alice→Charlie €7, proving results are independent of insertion order |


### PR DESCRIPTION
## Summary

- The previous settlement algorithm matched debtors to creditors in participant insertion order, producing non-deterministic results — the same group with the same expenses could generate different reimbursements depending on who was added first
- Replaced with a sorted greedy (min cash flow) approach: both debtors and creditors are sorted by amount descending before the two-pointer matching loop
- Results are now deterministic regardless of insertion order, and largest transactions appear first (more intuitive for users)
- Balance calculation (`calculateBalances`) is unchanged

## Test plan

- [x] All 10 existing `SettlementCalculatorTest` tests pass unchanged
- [x] `calculate_largestDebtSettledFirst_regardlessOfInsertionOrder` — verifies correct sorted transaction sequence for a 4-person scenario
- [x] `calculate_sortingIsDeterministic_regardlessOfInsertionOrder` — same balances with reversed insertion order produces identical first transaction

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)