### PR TITLE
feat: select all content on focus for numeric inputs

### DIFF
--- a/fairnsquare-app/src/main/doc/implementation/2026-02-27-Feature-numeric-input-select-all.md
+++ b/fairnsquare-app/src/main/doc/implementation/2026-02-27-Feature-numeric-input-select-all.md
@@ -1,0 +1,41 @@
+# Feature: Numeric Input Select-All on Focus
+
+**Date:** 2026-02-27
+
+## What, Why and Constraints
+
+**What:** When a user clicks (or tabs into) a numeric input field, the entire existing value is automatically selected.
+
+**Why:** Without this behavior, users must manually clear the existing value before typing a new one, which is a common usability friction point for numeric entry forms (expense amounts, share parts).
+
+**Constraints:**
+- `input.select()` on `<input type="number">` is not reliably synchronous in Chrome — the selection must be deferred via `setTimeout(() => el.select(), 0)` to work cross-browser.
+- The implementation must not break any parent-provided `onfocus` handlers — they must still be called.
+- The `onfocus` prop must be destructured out of `restProps` before spreading to prevent the spread from overriding the internal handler.
+
+## How
+
+**Single file modified:** `fairnsquare-app/src/main/webui/src/lib/components/ui/input/input.svelte`
+
+1. Destructured `onfocus` as `onFocusProp` from the component's props, so it is no longer part of `restProps`.
+2. Added a `handleFocus` function that:
+   - Calls `setTimeout(() => ref?.select(), 0)` when `type === 'number'` (deferred to ensure cross-browser compatibility).
+   - Chains the caller's `onFocusProp` if provided.
+3. Applied `onfocus={handleFocus}` on the non-file `<input>` element, placed **after** `{...restProps}` so it always wins.
+
+This centralised the behavior in the shared input component — all numeric inputs across the application (expense amount, share parts) benefit automatically with zero changes to parent components.
+
+**File created:** `fairnsquare-app/src/main/webui/src/lib/components/ui/input/input.test.ts`
+
+## Tests
+
+**New test file:** `src/lib/components/ui/input/input.test.ts` — 4 tests
+
+| Test | What it covers |
+|------|----------------|
+| `calls select() on the input element when a number input is focused` | Core behavior: `select()` is deferred and called via `setTimeout` |
+| `does not call select() when a text input is focused` | Non-regression: text inputs are unaffected |
+| `still calls a parent-provided onfocus handler when focused` | Chaining: caller's `onfocus` is not lost |
+| `calls both select() and a parent onfocus for number inputs` | Combined: both behaviors fire together |
+
+All 339 tests pass (12 test files).

--- a/fairnsquare-app/src/main/webui/src/lib/components/ui/input/input.svelte
+++ b/fairnsquare-app/src/main/webui/src/lib/components/ui/input/input.svelte
@@ -16,8 +16,16 @@
 		files = $bindable(),
 		class: className,
 		"data-slot": dataSlot = "input",
+		onfocus: onFocusProp,
 		...restProps
 	}: Props = $props();
+
+	function handleFocus(event: FocusEvent) {
+		if (type === 'number' && ref) {
+			setTimeout(() => ref?.select(), 0);
+		}
+		(onFocusProp as ((e: FocusEvent) => void) | undefined)?.(event);
+	}
 </script>
 
 {#if type === "file"}
@@ -48,5 +56,6 @@
 		{type}
 		bind:value
 		{...restProps}
+		onfocus={handleFocus}
 	/>
 {/if}

--- a/fairnsquare-app/src/main/webui/src/lib/components/ui/input/input.test.ts
+++ b/fairnsquare-app/src/main/webui/src/lib/components/ui/input/input.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/svelte';
+import Input from './input.svelte';
+
+describe('Input component', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('Select-all on focus for number inputs', () => {
+    it('calls select() on the input element when a number input is focused', async () => {
+      render(Input, { props: { type: 'number', value: 42 } });
+
+      const input = screen.getByRole('spinbutton') as HTMLInputElement;
+      const selectSpy = vi.spyOn(input, 'select');
+
+      await fireEvent.focus(input);
+      vi.runAllTimers();
+
+      expect(selectSpy).toHaveBeenCalledOnce();
+    });
+
+    it('does not call select() when a text input is focused', async () => {
+      render(Input, { props: { type: 'text', value: 'hello' } });
+
+      const input = screen.getByRole('textbox') as HTMLInputElement;
+      const selectSpy = vi.spyOn(input, 'select');
+
+      await fireEvent.focus(input);
+      vi.runAllTimers();
+
+      expect(selectSpy).not.toHaveBeenCalled();
+    });
+
+    it('still calls a parent-provided onfocus handler when focused', async () => {
+      const onFocus = vi.fn();
+      render(Input, { props: { type: 'number', value: 10, onfocus: onFocus } });
+
+      const input = screen.getByRole('spinbutton') as HTMLInputElement;
+
+      await fireEvent.focus(input);
+
+      expect(onFocus).toHaveBeenCalledOnce();
+    });
+
+    it('calls both select() and a parent onfocus for number inputs', async () => {
+      const onFocus = vi.fn();
+      render(Input, { props: { type: 'number', value: 10, onfocus: onFocus } });
+
+      const input = screen.getByRole('spinbutton') as HTMLInputElement;
+      const selectSpy = vi.spyOn(input, 'select');
+
+      await fireEvent.focus(input);
+      vi.runAllTimers();
+
+      expect(selectSpy).toHaveBeenCalledOnce();
+      expect(onFocus).toHaveBeenCalledOnce();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds select-all behavior to all `<input type="number">` fields when focused (click or tab)
- Implemented centrally in the shared `input.svelte` component — no changes needed in parent components
- Uses `setTimeout(() => ref?.select(), 0)` for cross-browser compatibility (Chrome requires the deferred call)
- Parent-provided `onfocus` handlers are preserved via chaining

## Test plan

- [x] New test file `input.test.ts` with 4 tests covering: select-all on number focus, no-op on text focus, parent `onfocus` chaining, and both behaviors together
- [x] Full test suite passes: 339/339 tests across 12 files

🤖 Generated with [Claude Code](https://claude.com/claude-code)