### PR TITLE
feat: make settled splits read-only with Unsettle action

### DIFF
--- a/fairnsquare-app/src/main/doc/implementation/2026-03-16-Feature-settled-readonly.md
+++ b/fairnsquare-app/src/main/doc/implementation/2026-03-16-Feature-settled-readonly.md
@@ -1,0 +1,86 @@
+# Feature: Settled Read-Only Mode + Unsettle
+
+## What, Why and Constraints
+
+**What:** When a split is settled (`split.settlement != null`), the UI becomes read-only — no adding, editing, or deleting of expenses or participants is possible. An amber banner is shown on the Participants and ExpenseList pages to inform the user and link to the settlement. An **Unsettle** button appears on the Settlement page (below the Export Settlement button, visible only when reimbursements are shown) to clear the settlement and restore editing.
+
+**Why:** A resolved split should be protected from accidental edits that would silently invalidate the settlement. The explicit Unsettle action makes reverting to an editable state intentional.
+
+**Constraints:**
+- The `DELETE /splits/{id}/settlement` endpoint was new — no existing infrastructure.
+- `Split.clearSettlement()` already existed in the domain model.
+- The Svelte 5 `$derived` pattern was used for `isSettled` to keep the settled state reactively consistent with the split data.
+- Settlement page already called `resolveSettlement` (POST) on every load — the Unsettle flow reuses that call to refresh the calculated settlement after unsettling.
+
+## How
+
+### Backend
+
+**`SplitUseCases.java`** — Added `unsettleSettlement(String splitId)`:
+- Loads the split, calls `split.clearSettlement()`, saves, returns `true`.
+- Returns `false` if the split is not found (used to distinguish 404 from success).
+
+**`SplitResource.java`** — Added `DELETE /splits/{id}/settlement`:
+- Validates the split ID format (400 if invalid).
+- Calls `splitService.unsettleSettlement(splitId)`; returns 404 if split not found, 204 No Content on success.
+
+### Frontend API
+
+**`splits.ts`** — Added `unsettleSettlement(splitId)`:
+- Calls `DELETE /splits/{splitId}/settlement`.
+- Already imported `unsettleSettlement` in `Settlement.svelte`.
+
+### Frontend — Settlement page
+
+**`Settlement.svelte`** — Added Unsettle button:
+- New state: `let isUnsettling = $state(false)`.
+- `handleUnsettle()`: calls `unsettleSettlement`, resets `showReimbursements = false`, reloads `getSplit` + `resolveSettlement` in parallel.
+- Unsettle button renders below Export Settlement, only when `showReimbursements` is true. Uses `ghost` variant with muted text, disabled while `isUnsettling`.
+
+### Frontend — Participants page
+
+**`Participants.svelte`** — Read-only when settled:
+- `const isSettled = $derived(split?.settlement != null)`.
+- Amber banner shown after the header when `isSettled`, with a "View settlement" `<button>` navigating to the settlement page.
+- Add Participant button/form gated with `{#if !isSettled}`.
+- Per-card Edit, Delete, and Add Expense buttons gated with `{#if !isSettled}`.
+
+### Frontend — ExpenseList page
+
+**`ExpenseList.svelte`** — Read-only when settled:
+- `const isSettled = $derived(split?.settlement != null)`.
+- Amber banner shown after the header when `isSettled`.
+- Add Expense button gated with `{#if !isSettled}`.
+- Per-card Edit and Delete action row gated with `{#if !isSettled}`.
+
+## Tests
+
+### Backend (`SettlementUseCaseTest.java`)
+
+Four new integration tests added:
+- `unsettleSettlement_afterCalculation_returns204()` — POST then DELETE → 204
+- `unsettleSettlement_afterCalculation_clearsSettlement()` — POST → DELETE → GET → 404
+- `unsettleSettlement_withInvalidSplitId_returns400()` — invalid ID → 400
+- `unsettleSettlement_withUnknownSplitId_returns404()` — unknown split → 404
+
+Total: 12 tests (all passing).
+
+### Frontend
+
+**`Settlement.test.ts`** — 6 Unsettle tests:
+- Unsettle button absent before Resolve; present after Resolve and when already persisted.
+- Calls `unsettleSettlement` + reloads on click.
+- Resets to pre-resolve state (Resolve button shown, reimbursements hidden).
+- Error toast on failure.
+
+**`Participants.test.ts`** — 7 settled read-only tests:
+- Settled banner shown/hidden correctly.
+- "View settlement" link navigates to settlement page.
+- Add Participant, Edit, Delete, Add Expense buttons absent when settled.
+
+**`ExpenseList.test.ts`** — 7 settled read-only tests:
+- Settled banner shown/hidden correctly.
+- "View settlement" link navigates to settlement page.
+- Add Expense, Edit, Delete buttons absent when settled.
+
+Total frontend tests: 401 (all passing).

--- a/fairnsquare-app/src/main/java/org/asymetrik/web/fairnsquare/split/api/SplitResource.java
+++ b/fairnsquare-app/src/main/java/org/asymetrik/web/fairnsquare/split/api/SplitResource.java
@@ -149,6 +149,32 @@ public class SplitResource {
     }
 
     /**
+     * Clears the persisted settlement for a split (unsettle).
+     *
+     * @param splitId
+     *            the split identifier
+     *
+     * @return 204 No Content if cleared, 404 Not Found if split does not exist, 400 Bad Request for invalid ID
+     */
+    @Operation(summary = "Unsettle", description = "Clears the persisted settlement for a split, allowing participants and expenses to be edited again.")
+    @APIResponse(responseCode = "204", description = "Settlement cleared")
+    @APIResponse(responseCode = "404", description = "Split not found")
+    @APIResponse(responseCode = "400", description = "Invalid split ID format")
+    @DELETE
+    @Path("/{splitId}/settlement")
+    public Response unsettleSettlement(@PathParam("splitId") String splitId) {
+        if (!Split.Id.isValid(splitId)) {
+            throw new InvalidSplitIdError(splitId);
+        }
+
+        if (!splitService.unsettleSettlement(splitId)) {
+            throw new SplitNotFoundError(splitId);
+        }
+
+        return Response.noContent().build();
+    }
+
+    /**
      * Adds a participant to a split.
      *
      * @param splitId

--- a/fairnsquare-app/src/main/java/org/asymetrik/web/fairnsquare/split/service/SplitUseCases.java
+++ b/fairnsquare-app/src/main/java/org/asymetrik/web/fairnsquare/split/service/SplitUseCases.java
@@ -104,6 +104,22 @@ public class SplitUseCases {
     }
 
     /**
+     * Clears the persisted settlement for a split (unsettle).
+     *
+     * @param splitId
+     *            the split identifier
+     *
+     * @return true if the split was found and unsettled, false if the split does not exist
+     */
+    public boolean unsettleSettlement(@LogTag("splitId") String splitId) {
+        return repository.load(splitId).map(split -> {
+            split.clearSettlement();
+            repository.save(split);
+            return true;
+        }).orElse(false);
+    }
+
+    /**
      * Checks if a split exists.
      *
      * @param splitId

--- a/fairnsquare-app/src/main/webui/src/lib/api/splits.ts
+++ b/fairnsquare-app/src/main/webui/src/lib/api/splits.ts
@@ -260,3 +260,11 @@ export async function getSettlement(splitId: string): Promise<Settlement> {
 export async function resolveSettlement(splitId: string): Promise<Settlement> {
   return apiRequest<Settlement>(`/splits/${splitId}/settlement`, { method: 'POST' });
 }
+
+/**
+ * Clears the persisted settlement for a split, returning it to an editable state.
+ * @param splitId The split identifier
+ */
+export async function unsettleSettlement(splitId: string): Promise<void> {
+  await apiRequest<void>(`/splits/${splitId}/settlement`, { method: 'DELETE' });
+}

--- a/fairnsquare-app/src/main/webui/src/routes/ExpenseList.svelte
+++ b/fairnsquare-app/src/main/webui/src/routes/ExpenseList.svelte
@@ -16,6 +16,7 @@
 
   // State
   let split = $state<Split | null>(null);
+  const isSettled = $derived(split?.settlement != null);
   let isLoading = $state(true);
 
   // Delete confirmation state
@@ -283,6 +284,16 @@
     <!-- Header -->
     <SplitPageHeader splitName={split.name} {splitId} showBackButton />
 
+    <!-- Settled Banner -->
+    {#if isSettled}
+      <div class="w-full flex items-center gap-2 px-3 py-2 rounded-md bg-amber-50 border border-amber-200 text-sm text-amber-800">
+        <span class="flex-1">This split is settled — expenses are read-only.</span>
+        <button onclick={() => navigate(`/splits/${splitId}/settlement`)} class="underline font-medium whitespace-nowrap">
+          View settlement
+        </button>
+      </div>
+    {/if}
+
     <!-- Filter Bar -->
     {#if split.participants.length > 0}
       <section class="w-full" aria-label="Expense filters">
@@ -343,14 +354,16 @@
     </section>
 
     <!-- Add Expense Button -->
-    <Button
-      onclick={handleAddExpense}
-      variant="outline"
-      class="w-full min-h-[44px]"
-    >
-      <Plus class="h-4 w-4 mr-1" />
-      Add Expense
-    </Button>
+    {#if !isSettled}
+      <Button
+        onclick={handleAddExpense}
+        variant="outline"
+        class="w-full min-h-[44px]"
+      >
+        <Plus class="h-4 w-4 mr-1" />
+        Add Expense
+      </Button>
+    {/if}
 
     {#if sortedExpenses.length === 0}
       <!-- Empty State - no expenses at all -->
@@ -401,26 +414,28 @@
               </div>
 
               <!-- Row 4: Actions -->
-              <div class="flex items-center justify-end gap-1">
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onclick={() => handleEditClick(expense)}
-                  class="min-h-[44px] min-w-[44px]"
-                  aria-label="Edit expense: {expense.description}"
-                >
-                  <Pencil class="h-4 w-4" />
-                </Button>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onclick={() => handleDeleteClick(expense)}
-                  class="min-h-[44px] min-w-[44px] text-destructive hover:text-destructive"
-                  aria-label="Delete expense: {expense.description}"
-                >
-                  <Trash2 class="h-4 w-4" />
-                </Button>
-              </div>
+              {#if !isSettled}
+                <div class="flex items-center justify-end gap-1">
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onclick={() => handleEditClick(expense)}
+                    class="min-h-[44px] min-w-[44px]"
+                    aria-label="Edit expense: {expense.description}"
+                  >
+                    <Pencil class="h-4 w-4" />
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onclick={() => handleDeleteClick(expense)}
+                    class="min-h-[44px] min-w-[44px] text-destructive hover:text-destructive"
+                    aria-label="Delete expense: {expense.description}"
+                  >
+                    <Trash2 class="h-4 w-4" />
+                  </Button>
+                </div>
+              {/if}
             </Card.Content>
           </Card.Root>
         {/each}

--- a/fairnsquare-app/src/main/webui/src/routes/ExpenseList.test.ts
+++ b/fairnsquare-app/src/main/webui/src/routes/ExpenseList.test.ts
@@ -130,6 +130,19 @@ const mockSplitForFilters: SplitType = {
   ],
 };
 
+const mockSplitSettled: SplitType = {
+  ...mockSplitWithExpenses,
+  settlement: {
+    balances: [
+      { participantId: 'p1', participantName: 'Alice', totalPaid: 90, totalCost: 75, balance: 15 },
+      { participantId: 'p2', participantName: 'Bob', totalPaid: 60, totalCost: 75, balance: -15 },
+    ],
+    reimbursements: [
+      { fromId: 'p2', fromName: 'Bob', toId: 'p1', toName: 'Alice', amount: 15 },
+    ],
+  },
+};
+
 describe('ExpenseList', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -675,6 +688,82 @@ describe('ExpenseList', () => {
       await waitFor(() => {
         expect(screen.getByText('No matching expenses')).toBeInTheDocument();
       });
+    });
+  });
+
+  // --- Settled read-only mode ---
+
+  describe('Settled read-only mode', () => {
+    it('shows settled banner when split is settled', async () => {
+      vi.mocked(getSplit).mockResolvedValue(mockSplitSettled);
+
+      render(ExpenseList);
+
+      await waitFor(() => {
+        expect(screen.getByText(/This split is settled/)).toBeInTheDocument();
+      });
+    });
+
+    it('shows "View settlement" link in the settled banner', async () => {
+      vi.mocked(getSplit).mockResolvedValue(mockSplitSettled);
+
+      render(ExpenseList);
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: 'View settlement' })).toBeInTheDocument();
+      });
+    });
+
+    it('"View settlement" link navigates to the settlement page', async () => {
+      vi.mocked(getSplit).mockResolvedValue(mockSplitSettled);
+
+      render(ExpenseList);
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: 'View settlement' })).toBeInTheDocument();
+      });
+
+      await fireEvent.click(screen.getByRole('button', { name: 'View settlement' }));
+      expect(navigate).toHaveBeenCalledWith('/splits/test-split-id-00001/settlement');
+    });
+
+    it('does not show Add Expense button when settled', async () => {
+      vi.mocked(getSplit).mockResolvedValue(mockSplitSettled);
+
+      render(ExpenseList);
+
+      await waitFor(() => {
+        expect(screen.getByText(/This split is settled/)).toBeInTheDocument();
+      });
+
+      expect(screen.queryByRole('button', { name: /add expense/i })).not.toBeInTheDocument();
+    });
+
+    it('does not show Edit and Delete buttons on expense cards when settled', async () => {
+      vi.mocked(getSplit).mockResolvedValue(mockSplitSettled);
+
+      render(ExpenseList);
+
+      await waitFor(() => {
+        expect(screen.getByText('Groceries')).toBeInTheDocument();
+      });
+
+      expect(screen.queryByRole('button', { name: 'Edit expense: Groceries' })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'Delete expense: Groceries' })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'Edit expense: Dinner' })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'Delete expense: Dinner' })).not.toBeInTheDocument();
+    });
+
+    it('does not show settled banner when split is not settled', async () => {
+      vi.mocked(getSplit).mockResolvedValue(mockSplitWithExpenses);
+
+      render(ExpenseList);
+
+      await waitFor(() => {
+        expect(screen.getByText('Groceries')).toBeInTheDocument();
+      });
+
+      expect(screen.queryByText(/This split is settled/)).not.toBeInTheDocument();
     });
   });
 });

--- a/fairnsquare-app/src/main/webui/src/routes/Participants.svelte
+++ b/fairnsquare-app/src/main/webui/src/routes/Participants.svelte
@@ -38,6 +38,7 @@
   const sortedParticipants = $derived(
     split?.participants.slice().sort((a, b) => a.name.localeCompare(b.name)) ?? []
   );
+  const isSettled = $derived(split?.settlement != null);
   let isLoading = $state(true);
 
   // Add Participant form state
@@ -398,11 +399,24 @@
     <!-- Header -->
     <SplitPageHeader splitName={split.name} {splitId} showBackButton />
 
+    <!-- Settled Banner -->
+    {#if isSettled}
+      <div class="w-full flex items-center gap-2 px-3 py-2 rounded-md bg-amber-50 border border-amber-200 text-sm text-amber-800">
+        <span class="flex-1">This split is settled — participants are read-only.</span>
+        <button
+          onclick={() => navigate(`/splits/${splitId}/settlement`)}
+          class="underline font-medium whitespace-nowrap"
+        >
+          View settlement
+        </button>
+      </div>
+    {/if}
+
     <!-- Participants Summary Card -->
     <ParticipantSummaryCard participants={split.participants} showTitle={false} />
 
-    <!-- Add Participant Form / Button -->
-    {#if showAddForm}
+    <!-- Add Participant Form / Button (hidden when settled) -->
+    {#if !isSettled && showAddForm}
       <Card.Root class="w-full">
         <Card.Content class="py-4">
           <form onsubmit={(e) => { e.preventDefault(); handleAddParticipant(); }} class="space-y-3">
@@ -482,7 +496,7 @@
           </form>
         </Card.Content>
       </Card.Root>
-    {:else}
+    {:else if !isSettled}
       <Button
         onclick={handleShowAddForm}
         variant="outline"
@@ -508,40 +522,42 @@
             <!-- Row 1: name + action buttons -->
             <div class="flex items-center justify-between gap-2">
               <span class="font-semibold text-lg truncate min-w-0 flex-1">{formatName(participant.name)}</span>
-              <!-- Action Buttons -->
-              <div class="flex-none flex items-center gap-1">
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onclick={(e) => handleAddExpenseClick(e, participant)}
-                  class="text-primary hover:text-primary hover:bg-primary/10 min-h-[44px] min-w-[44px]"
-                  aria-label={`Add expense for ${participant.name}`}
-                >
-                  <Plus class="h-4 w-4" />
-                </Button>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onclick={() => handleStartEdit(participant)}
-                  class="min-h-[44px] min-w-[44px]"
-                  aria-label={`Edit ${participant.name}`}
-                >
-                  <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
-                    <path d="M13.586 3.586a2 2 0 112.828 2.828l-.793.793-2.828-2.828.793-.793zM11.379 5.793L3 14.172V17h2.828l8.38-8.379-2.83-2.828z" />
-                  </svg>
-                </Button>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onclick={(e) => handleDeleteClick(e, participant)}
-                  class="text-destructive hover:text-destructive hover:bg-destructive/10 min-h-[44px] min-w-[44px]"
-                  aria-label={`Delete ${participant.name}`}
-                >
-                  <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
-                    <path fill-rule="evenodd" d="M9 2a1 1 0 00-.894.553L7.382 4H4a1 1 0 000 2v10a2 2 0 002 2h8a2 2 0 002-2V6a1 1 0 100-2h-3.382l-.724-1.447A1 1 0 0011 2H9zM7 8a1 1 0 012 0v6a1 1 0 11-2 0V8zm5-1a1 1 0 00-1 1v6a1 1 0 102 0V8a1 1 0 00-1-1z" clip-rule="evenodd" />
-                  </svg>
-                </Button>
-              </div>
+              <!-- Action Buttons (hidden when settled) -->
+              {#if !isSettled}
+                <div class="flex-none flex items-center gap-1">
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onclick={(e) => handleAddExpenseClick(e, participant)}
+                    class="text-primary hover:text-primary hover:bg-primary/10 min-h-[44px] min-w-[44px]"
+                    aria-label={`Add expense for ${participant.name}`}
+                  >
+                    <Plus class="h-4 w-4" />
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onclick={() => handleStartEdit(participant)}
+                    class="min-h-[44px] min-w-[44px]"
+                    aria-label={`Edit ${participant.name}`}
+                  >
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
+                      <path d="M13.586 3.586a2 2 0 112.828 2.828l-.793.793-2.828-2.828.793-.793zM11.379 5.793L3 14.172V17h2.828l8.38-8.379-2.83-2.828z" />
+                    </svg>
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onclick={(e) => handleDeleteClick(e, participant)}
+                    class="text-destructive hover:text-destructive hover:bg-destructive/10 min-h-[44px] min-w-[44px]"
+                    aria-label={`Delete ${participant.name}`}
+                  >
+                    <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" viewBox="0 0 20 20" fill="currentColor">
+                      <path fill-rule="evenodd" d="M9 2a1 1 0 00-.894.553L7.382 4H4a1 1 0 000 2v10a2 2 0 002 2h8a2 2 0 002-2V6a1 1 0 100-2h-3.382l-.724-1.447A1 1 0 0011 2H9zM7 8a1 1 0 012 0v6a1 1 0 11-2 0V8zm5-1a1 1 0 00-1 1v6a1 1 0 102 0V8a1 1 0 00-1-1z" clip-rule="evenodd" />
+                    </svg>
+                  </Button>
+                </div>
+              {/if}
             </div>
             <!-- Row 2: badges -->
             <div class="flex flex-wrap items-center gap-1">

--- a/fairnsquare-app/src/main/webui/src/routes/Participants.test.ts
+++ b/fairnsquare-app/src/main/webui/src/routes/Participants.test.ts
@@ -1043,6 +1043,108 @@ describe('Participants', () => {
     });
   });
 
+  // --- Settled read-only mode ---
+
+  describe('Settled read-only mode', () => {
+    const mockSplitSettled: SplitType = {
+      ...mockSplitWithData,
+      settlement: {
+        balances: [
+          { participantId: 'p1', participantName: 'Alice', totalPaid: 90, totalCost: 75, balance: 15 },
+          { participantId: 'p2', participantName: 'Bob', totalPaid: 60, totalCost: 75, balance: -15 },
+        ],
+        reimbursements: [
+          { fromId: 'p2', fromName: 'Bob', toId: 'p1', toName: 'Alice', amount: 15 },
+        ],
+      },
+    };
+
+    it('shows settled banner when split is settled', async () => {
+      vi.mocked(getSplit).mockResolvedValue(mockSplitSettled);
+
+      render(Participants);
+
+      await waitFor(() => {
+        expect(screen.getByText(/This split is settled/)).toBeInTheDocument();
+      });
+    });
+
+    it('shows "View settlement" link in the settled banner', async () => {
+      vi.mocked(getSplit).mockResolvedValue(mockSplitSettled);
+
+      render(Participants);
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: 'View settlement' })).toBeInTheDocument();
+      });
+    });
+
+    it('"View settlement" link navigates to the settlement page', async () => {
+      vi.mocked(getSplit).mockResolvedValue(mockSplitSettled);
+
+      render(Participants);
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: 'View settlement' })).toBeInTheDocument();
+      });
+
+      await fireEvent.click(screen.getByRole('button', { name: 'View settlement' }));
+      expect(navigate).toHaveBeenCalledWith('/splits/test-split-id/settlement');
+    });
+
+    it('does not show Add Participant button when settled', async () => {
+      vi.mocked(getSplit).mockResolvedValue(mockSplitSettled);
+
+      render(Participants);
+
+      await waitFor(() => {
+        expect(screen.getByText(/This split is settled/)).toBeInTheDocument();
+      });
+
+      expect(screen.queryByRole('button', { name: /Add Participant/i })).not.toBeInTheDocument();
+    });
+
+    it('does not show Edit and Delete buttons on participant cards when settled', async () => {
+      vi.mocked(getSplit).mockResolvedValue(mockSplitSettled);
+
+      render(Participants);
+
+      await waitFor(() => {
+        expect(screen.getByText('Alice')).toBeInTheDocument();
+      });
+
+      expect(screen.queryByRole('button', { name: 'Edit Alice' })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'Delete Alice' })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'Edit Bob' })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'Delete Bob' })).not.toBeInTheDocument();
+    });
+
+    it('does not show Add Expense button on participant cards when settled', async () => {
+      vi.mocked(getSplit).mockResolvedValue(mockSplitSettled);
+
+      render(Participants);
+
+      await waitFor(() => {
+        expect(screen.getByText('Alice')).toBeInTheDocument();
+      });
+
+      expect(screen.queryByRole('button', { name: 'Add expense for Alice' })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'Add expense for Bob' })).not.toBeInTheDocument();
+    });
+
+    it('does not show settled banner when split is not settled', async () => {
+      vi.mocked(getSplit).mockResolvedValue(mockSplitWithData);
+
+      render(Participants);
+
+      await waitFor(() => {
+        expect(screen.getByText('Alice')).toBeInTheDocument();
+      });
+
+      expect(screen.queryByText(/This split is settled/)).not.toBeInTheDocument();
+    });
+  });
+
   describe('Auto-open from Home creation flow', () => {
     it('auto-opens add form when addParticipant search param is present', async () => {
       vi.mocked(getSplit).mockResolvedValue(mockSplitEmpty);

--- a/fairnsquare-app/src/main/webui/src/routes/Settlement.svelte
+++ b/fairnsquare-app/src/main/webui/src/routes/Settlement.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   // Settlement Page - Balances & Reimbursement Proposals
 
-  import { getSplit, resolveSettlement, updateParticipant, type Settlement, type Split } from '$lib/api/splits';
+  import { getSplit, resolveSettlement, unsettleSettlement, updateParticipant, type Settlement, type Split } from '$lib/api/splits';
   import type { ApiError } from '$lib/api/client';
   import { Button } from '$lib/components/ui/button';
   import * as Card from '$lib/components/ui/card';
@@ -17,6 +17,7 @@
   let splitName = $state('');
   let isLoading = $state(true);
   let showReimbursements = $state(false);
+  let isUnsettling = $state(false);
 
   // On mount: calculate the settlement (POST) to show balances immediately.
   // If a settlement is already persisted, show reimbursements directly.
@@ -146,6 +147,21 @@
     }
   }
 
+  async function handleUnsettle() {
+    isUnsettling = true;
+    try {
+      await unsettleSettlement(splitId);
+      showReimbursements = false;
+      const [splitData, settlementData] = await Promise.all([getSplit(splitId), resolveSettlement(splitId)]);
+      split = splitData;
+      settlement = settlementData;
+    } catch (err: any) {
+      addToast({ type: 'error', message: err.detail || 'Failed to unsettle' });
+    } finally {
+      isUnsettling = false;
+    }
+  }
+
   async function handlePreferredCreditorChange(participantId: string, creditorId: string) {
     if (!split) return;
     const participant = split.participants.find(p => p.id === participantId);
@@ -195,7 +211,7 @@
       {#if settlement.balances.length === 0}
         <p class="text-muted-foreground text-center py-4">No participants</p>
       {:else}
-        <!-- Action Button (before cards, consistent with Add Participant / Add Expense placement) -->
+        <!-- Action Buttons (before cards, consistent with Add Participant / Add Expense placement) -->
         {#if showReimbursements}
           <Button
             onclick={handleExportSettlement}
@@ -203,6 +219,14 @@
             class="w-full min-h-[44px]"
           >
             Export Settlement
+          </Button>
+          <Button
+            onclick={handleUnsettle}
+            disabled={isUnsettling}
+            variant="ghost"
+            class="w-full min-h-[44px] text-muted-foreground"
+          >
+            {isUnsettling ? 'Unsettling...' : 'Unsettle'}
           </Button>
         {:else}
           <Button

--- a/fairnsquare-app/src/main/webui/src/routes/Settlement.test.ts
+++ b/fairnsquare-app/src/main/webui/src/routes/Settlement.test.ts
@@ -21,6 +21,7 @@ vi.mock('$lib/api/splits', () => ({
   getSplit: vi.fn(),
   resolveSettlement: vi.fn(),
   updateParticipant: vi.fn(),
+  unsettleSettlement: vi.fn(),
 }));
 
 // Mock the toast store
@@ -28,7 +29,7 @@ vi.mock('$lib/stores/toastStore.svelte', () => ({
   addToast: vi.fn(),
 }));
 
-import { getSplit, resolveSettlement, updateParticipant } from '$lib/api/splits';
+import { getSplit, resolveSettlement, updateParticipant, unsettleSettlement } from '$lib/api/splits';
 import { navigate, route } from '$lib/router';
 import { addToast } from '$lib/stores/toastStore.svelte';
 
@@ -111,6 +112,7 @@ describe('Settlement', () => {
       share: 1,
       preferredCreditorId: null,
     });
+    vi.mocked(unsettleSettlement).mockResolvedValue(undefined);
   });
 
   // --- Loading State ---
@@ -704,6 +706,92 @@ describe('Settlement', () => {
 
       await waitFor(() => {
         expect(addToast).toHaveBeenCalledWith({ type: 'error', message: 'Save failed' });
+      });
+    });
+  });
+
+  // --- Unsettle ---
+
+  describe('Unsettle', () => {
+    it('does not show Unsettle button before clicking Resolve', async () => {
+      render(Settlement);
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: 'Resolve' })).toBeInTheDocument();
+      });
+
+      expect(screen.queryByRole('button', { name: 'Unsettle' })).not.toBeInTheDocument();
+    });
+
+    it('shows Unsettle button after clicking Resolve', async () => {
+      render(Settlement);
+
+      await waitFor(() => expect(screen.getByRole('button', { name: 'Resolve' })).toBeInTheDocument());
+      await fireEvent.click(screen.getByRole('button', { name: 'Resolve' }));
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: 'Unsettle' })).toBeInTheDocument();
+      });
+    });
+
+    it('shows Unsettle button when split already has a persisted settlement', async () => {
+      vi.mocked(getSplit).mockResolvedValue(mockSplitWithSettlement);
+
+      render(Settlement);
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: 'Unsettle' })).toBeInTheDocument();
+      });
+    });
+
+    it('calls unsettleSettlement and reloads when Unsettle is clicked', async () => {
+      render(Settlement);
+
+      await waitFor(() => expect(screen.getByRole('button', { name: 'Resolve' })).toBeInTheDocument());
+      await fireEvent.click(screen.getByRole('button', { name: 'Resolve' }));
+
+      await waitFor(() => expect(screen.getByRole('button', { name: 'Unsettle' })).toBeInTheDocument());
+      await fireEvent.click(screen.getByRole('button', { name: 'Unsettle' }));
+
+      await waitFor(() => {
+        expect(unsettleSettlement).toHaveBeenCalledWith('test-split-id');
+        expect(getSplit).toHaveBeenCalledTimes(2);
+        expect(resolveSettlement).toHaveBeenCalledTimes(2);
+      });
+    });
+
+    it('resets to pre-resolve state (shows Resolve button, hides reimbursements) after unsettling', async () => {
+      render(Settlement);
+
+      await waitFor(() => expect(screen.getByRole('button', { name: 'Resolve' })).toBeInTheDocument());
+      await fireEvent.click(screen.getByRole('button', { name: 'Resolve' }));
+
+      await waitFor(() => {
+        expect(screen.getByText('Pay €50.00 to Alice')).toBeInTheDocument();
+      });
+
+      await fireEvent.click(screen.getByRole('button', { name: 'Unsettle' }));
+
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: 'Resolve' })).toBeInTheDocument();
+        expect(screen.queryByText('Pay €50.00 to Alice')).not.toBeInTheDocument();
+        expect(screen.queryByRole('button', { name: 'Unsettle' })).not.toBeInTheDocument();
+      });
+    });
+
+    it('shows error toast when unsettleSettlement fails', async () => {
+      vi.mocked(unsettleSettlement).mockRejectedValue({ detail: 'Unsettle failed' });
+
+      render(Settlement);
+
+      await waitFor(() => expect(screen.getByRole('button', { name: 'Resolve' })).toBeInTheDocument());
+      await fireEvent.click(screen.getByRole('button', { name: 'Resolve' }));
+
+      await waitFor(() => expect(screen.getByRole('button', { name: 'Unsettle' })).toBeInTheDocument());
+      await fireEvent.click(screen.getByRole('button', { name: 'Unsettle' }));
+
+      await waitFor(() => {
+        expect(addToast).toHaveBeenCalledWith({ type: 'error', message: 'Unsettle failed' });
       });
     });
   });

--- a/fairnsquare-app/src/test/java/org/asymetrik/web/fairnsquare/split/api/SettlementUseCaseTest.java
+++ b/fairnsquare-app/src/test/java/org/asymetrik/web/fairnsquare/split/api/SettlementUseCaseTest.java
@@ -91,6 +91,42 @@ class SettlementUseCaseTest {
                 .statusCode(404);
     }
 
+    // --- DELETE /api/splits/{id}/settlement ---
+
+    @Test
+    void unsettleSettlement_afterCalculation_returns204() {
+        String splitId = createSplitWithParticipantAndExpense();
+
+        given().contentType(ContentType.JSON).when().post("/api/splits/" + splitId + "/settlement").then()
+                .statusCode(200);
+
+        given().when().delete("/api/splits/" + splitId + "/settlement").then().statusCode(204);
+    }
+
+    @Test
+    void unsettleSettlement_afterCalculation_clearsSettlement() {
+        String splitId = createSplitWithParticipantAndExpense();
+
+        given().contentType(ContentType.JSON).when().post("/api/splits/" + splitId + "/settlement").then()
+                .statusCode(200);
+
+        // Unsettle
+        given().when().delete("/api/splits/" + splitId + "/settlement").then().statusCode(204);
+
+        // GET should now return 404 again
+        given().when().get("/api/splits/" + splitId + "/settlement").then().statusCode(404);
+    }
+
+    @Test
+    void unsettleSettlement_withInvalidSplitId_returns400() {
+        given().when().delete("/api/splits/not-a-valid-id/settlement").then().statusCode(400);
+    }
+
+    @Test
+    void unsettleSettlement_withUnknownSplitId_returns404() {
+        given().when().delete("/api/splits/nonExistentSplitId001/settlement").then().statusCode(404);
+    }
+
     // --- helpers ---
 
     /**

--- a/src/doc/rules/frontend-rules.md
+++ b/src/doc/rules/frontend-rules.md
@@ -55,6 +55,13 @@
 
 - When a page has a primary action button (e.g. Resolve, Add Participant, Add Expense), place it **after the header, before the content list or cards it acts upon**. This ensures the action is reachable without scrolling and is visually consistent across pages. Do not place primary action buttons below a list of items.
 
+## Read-Only UI State for Locked Resources
+
+- When a resource can be in a locked/read-only state (e.g. a settled split), derive the locked flag reactively using `$derived` from the resource data rather than a separate state variable.
+- Gate action buttons (Add, Edit, Delete) with `{#if !isLocked}` — never just disable them. Hidden actions cannot be accidentally triggered and avoid misleading affordances.
+- Show an amber banner that explains why editing is unavailable and provides a direct link/button to the action that would unlock the resource.
+- Keep the locked-state check in a single `$derived` per page and reference it everywhere on that page — do not duplicate the condition inline.
+
 ## Capturing Transient State Before Reset
 
 - When post-action feedback (e.g. a toast) needs to reference form state that is reset immediately after the API call, always capture those values into local `const` variables *before* the reset. Do not read from form state after it has been cleared — the values will reflect the reset defaults rather than the submitted data.


### PR DESCRIPTION
## Summary

- A settled split (`split.settlement != null`) is now read-only: Add, Edit, and Delete actions are hidden on the Participants and ExpenseList pages, replaced by an amber banner with a link to the settlement page
- New `DELETE /splits/{id}/settlement` backend endpoint (204) clears the persisted settlement and returns the split to an editable state
- The Settlement page gains an **Unsettle** button (below Export Settlement) that calls the new endpoint and resets to the pre-resolve state

## Test plan

- [ ] Backend: `SettlementUseCaseTest` — 4 new tests for DELETE endpoint (returns 204, clears settlement, 400 on invalid ID, 404 on unknown split)
- [ ] Frontend: `Settlement.test.ts` — 6 new Unsettle tests (button visibility, API call, state reset, error handling)
- [ ] Frontend: `Participants.test.ts` — 7 new settled read-only tests (banner, "View settlement" link, hidden actions)
- [ ] Frontend: `ExpenseList.test.ts` — 7 new settled read-only tests (banner, "View settlement" link, hidden actions)
- [ ] All 401 frontend tests pass
- [ ] Manual: settle a split, verify Participants and ExpenseList are read-only with banner; click Unsettle, verify editing is restored

🤖 Generated with [Claude Code](https://claude.com/claude-code)