### PR TITLE
feat: add BY_NIGHT_CUSTOM split mode for van guest participant management

### DIFF
--- a/fairnsquare-app/src/main/java/org/asymetrik/web/fairnsquare/infrastructure/captcha/package-info.java
+++ b/fairnsquare-app/src/main/java/org/asymetrik/web/fairnsquare/infrastructure/captcha/package-info.java
@@ -2,8 +2,7 @@
  * CAPTCHA infrastructure — stateless human-verification challenges. Contains image generation, AES-GCM encrypted
  * challenge tokens, HMAC-SHA256 proof tokens, the REST API, and the JAX-RS request filter.
  */
-@Module(name = "captcha", exports = { "org.asymetrik.web.fairnsquare.infrastructure.captcha.api",
-        "org.asymetrik.web.fairnsquare.infrastructure.captcha.domain" })
+@Module(name = "captcha", exports = { "org.asymetrik.web.fairnsquare.infrastructure.captcha.api" })
 package org.asymetrik.web.fairnsquare.infrastructure.captcha;
 
 import org.asymetrik.modular.api.Module;

--- a/fairnsquare-app/src/main/java/org/asymetrik/web/fairnsquare/split/api/SplitResource.java
+++ b/fairnsquare-app/src/main/java/org/asymetrik/web/fairnsquare/split/api/SplitResource.java
@@ -23,6 +23,7 @@ import org.asymetrik.web.fairnsquare.split.api.mapper.ParticipantMapper;
 import org.asymetrik.web.fairnsquare.split.api.mapper.SettlementMapper;
 import org.asymetrik.web.fairnsquare.split.api.mapper.SplitMapper;
 import org.asymetrik.web.fairnsquare.split.domain.expenses.Expense;
+import org.asymetrik.web.fairnsquare.split.service.AddByNightCustomExpenseRequest;
 import org.asymetrik.web.fairnsquare.split.service.AddExpenseRequest;
 import org.asymetrik.web.fairnsquare.split.service.AddFreeExpenseRequest;
 import org.asymetrik.web.fairnsquare.split.service.AddParticipantRequest;
@@ -425,6 +426,36 @@ public class SplitResource {
         }
 
         return splitService.addExpenseEqual(splitId, request.amount(), request.description(), request.payerId())
+                .flatMap(expense -> splitService.getSplit(splitId)
+                        .map(split -> Response.status(Response.Status.CREATED)
+                                .entity(expenseMapper.toDTO(expense, split)).build()))
+                .orElseThrow(() -> new SplitNotFoundError(splitId));
+    }
+
+    /**
+     * Adds a BY_NIGHT_CUSTOM expense to a split. Shares are calculated proportionally to participant nights, but only
+     * among the specified subset of participants.
+     *
+     * @param splitId
+     *            the split identifier
+     * @param request
+     *            the request containing amount, description, payerId, and included participant IDs
+     *
+     * @return 201 Created with the created expense, or 404 Not Found, or 400 Bad Request
+     */
+    @Operation(summary = "Add BY_NIGHT_CUSTOM expense", description = "Creates a by-night expense with a custom subset of participants")
+    @APIResponse(responseCode = "201", description = "Expense created successfully")
+    @APIResponse(responseCode = "404", description = "Split not found")
+    @APIResponse(responseCode = "400", description = "Invalid request or unknown participant IDs")
+    @POST
+    @Path("/{splitId}/expenses/by-night-custom")
+    public Response addExpenseByNightCustom(@PathParam("splitId") String splitId,
+            @Valid AddByNightCustomExpenseRequest request) {
+        if (!Split.Id.isValid(splitId)) {
+            throw new InvalidSplitIdError(splitId);
+        }
+
+        return splitService.addExpenseByNightCustom(splitId, request)
                 .flatMap(expense -> splitService.getSplit(splitId)
                         .map(split -> Response.status(Response.Status.CREATED)
                                 .entity(expenseMapper.toDTO(expense, split)).build()))

--- a/fairnsquare-app/src/main/java/org/asymetrik/web/fairnsquare/split/api/expense/dto/ExpenseByNightCustomDTO.java
+++ b/fairnsquare-app/src/main/java/org/asymetrik/web/fairnsquare/split/api/expense/dto/ExpenseByNightCustomDTO.java
@@ -1,0 +1,23 @@
+package org.asymetrik.web.fairnsquare.split.api.expense.dto;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * DTO for BY_NIGHT_CUSTOM expense type. Represents expenses split proportionally by nights stayed,
+ * but only among a custom subset of participants.
+ */
+public record ExpenseByNightCustomDTO(@JsonProperty("id") String id,
+        @JsonProperty("description") String description,
+        @JsonProperty("amount") BigDecimal amount, @JsonProperty("payerId") String payerId,
+        @JsonProperty("type") String type, @JsonProperty("splitMode") String splitMode,
+        @JsonProperty("createdAt") String createdAt, @JsonProperty("shares") List<ShareDTO> shares)
+        implements ExpenseDTO {
+
+    @JsonCreator
+    public ExpenseByNightCustomDTO {
+    }
+}

--- a/fairnsquare-app/src/main/java/org/asymetrik/web/fairnsquare/split/api/expense/dto/ExpenseByNightCustomDTO.java
+++ b/fairnsquare-app/src/main/java/org/asymetrik/web/fairnsquare/split/api/expense/dto/ExpenseByNightCustomDTO.java
@@ -7,11 +7,10 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
- * DTO for BY_NIGHT_CUSTOM expense type. Represents expenses split proportionally by nights stayed,
- * but only among a custom subset of participants.
+ * DTO for BY_NIGHT_CUSTOM expense type. Represents expenses split proportionally by nights stayed, but only among a
+ * custom subset of participants.
  */
-public record ExpenseByNightCustomDTO(@JsonProperty("id") String id,
-        @JsonProperty("description") String description,
+public record ExpenseByNightCustomDTO(@JsonProperty("id") String id, @JsonProperty("description") String description,
         @JsonProperty("amount") BigDecimal amount, @JsonProperty("payerId") String payerId,
         @JsonProperty("type") String type, @JsonProperty("splitMode") String splitMode,
         @JsonProperty("createdAt") String createdAt, @JsonProperty("shares") List<ShareDTO> shares)

--- a/fairnsquare-app/src/main/java/org/asymetrik/web/fairnsquare/split/api/expense/dto/ExpenseDTO.java
+++ b/fairnsquare-app/src/main/java/org/asymetrik/web/fairnsquare/split/api/expense/dto/ExpenseDTO.java
@@ -14,8 +14,10 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 @JsonSubTypes({ @JsonSubTypes.Type(value = ExpenseByNightDTO.class, name = "BY_NIGHT"),
         @JsonSubTypes.Type(value = ExpenseByShareDTO.class, name = "BY_SHARE"),
         @JsonSubTypes.Type(value = ExpenseEqualDTO.class, name = "EQUAL"),
-        @JsonSubTypes.Type(value = ExpenseFreeDTO.class, name = "FREE") })
-public sealed interface ExpenseDTO permits ExpenseByNightDTO, ExpenseByShareDTO, ExpenseEqualDTO, ExpenseFreeDTO {
+        @JsonSubTypes.Type(value = ExpenseFreeDTO.class, name = "FREE"),
+        @JsonSubTypes.Type(value = ExpenseByNightCustomDTO.class, name = "BY_NIGHT_CUSTOM") })
+public sealed interface ExpenseDTO
+        permits ExpenseByNightDTO, ExpenseByShareDTO, ExpenseEqualDTO, ExpenseFreeDTO, ExpenseByNightCustomDTO {
 
     String id();
 

--- a/fairnsquare-app/src/main/java/org/asymetrik/web/fairnsquare/split/api/expense/mapper/ExpenseMapper.java
+++ b/fairnsquare-app/src/main/java/org/asymetrik/web/fairnsquare/split/api/expense/mapper/ExpenseMapper.java
@@ -3,6 +3,7 @@ package org.asymetrik.web.fairnsquare.split.api.expense.mapper;
 import java.util.Collections;
 import java.util.List;
 
+import org.asymetrik.web.fairnsquare.split.api.expense.dto.ExpenseByNightCustomDTO;
 import org.asymetrik.web.fairnsquare.split.api.expense.dto.ExpenseByNightDTO;
 import org.asymetrik.web.fairnsquare.split.api.expense.dto.ExpenseByShareDTO;
 import org.asymetrik.web.fairnsquare.split.api.expense.dto.ExpenseDTO;
@@ -11,6 +12,7 @@ import org.asymetrik.web.fairnsquare.split.api.expense.dto.ExpenseFreeDTO;
 import org.asymetrik.web.fairnsquare.split.api.expense.dto.ShareDTO;
 import org.asymetrik.web.fairnsquare.split.domain.expenses.Expense;
 import org.asymetrik.web.fairnsquare.split.domain.expenses.ExpenseByNight;
+import org.asymetrik.web.fairnsquare.split.domain.expenses.ExpenseByNightCustom;
 import org.asymetrik.web.fairnsquare.split.domain.expenses.ExpenseByShare;
 import org.asymetrik.web.fairnsquare.split.domain.expenses.ExpenseEqual;
 import org.asymetrik.web.fairnsquare.split.domain.expenses.ExpenseFree;
@@ -51,6 +53,10 @@ public class ExpenseMapper {
             case ExpenseByNight byNight -> new ExpenseByNightDTO(byNight.getId().value(), byNight.getDescription(),
                     byNight.getAmount(), byNight.getPayerId() != null ? byNight.getPayerId().value() : null, "BY_NIGHT",
                     "BY_NIGHT", byNight.getCreatedAt().toString(), shares);
+            case ExpenseByNightCustom byNightCustom -> new ExpenseByNightCustomDTO(byNightCustom.getId().value(),
+                    byNightCustom.getDescription(), byNightCustom.getAmount(),
+                    byNightCustom.getPayerId() != null ? byNightCustom.getPayerId().value() : null, "BY_NIGHT_CUSTOM",
+                    "BY_NIGHT_CUSTOM", byNightCustom.getCreatedAt().toString(), shares);
             case ExpenseByShare byShare -> new ExpenseByShareDTO(byShare.getId().value(), byShare.getDescription(),
                     byShare.getAmount(), byShare.getPayerId() != null ? byShare.getPayerId().value() : null, "BY_SHARE",
                     "BY_SHARE", byShare.getCreatedAt().toString(), shares);

--- a/fairnsquare-app/src/main/java/org/asymetrik/web/fairnsquare/split/domain/expenses/Expense.java
+++ b/fairnsquare-app/src/main/java/org/asymetrik/web/fairnsquare/split/domain/expenses/Expense.java
@@ -13,7 +13,8 @@ import com.aventrix.jnanoid.jnanoid.NanoIdUtils;
  * Sealed abstract class representing a shared expense in a split. Each concrete subclass implements its own share
  * calculation strategy.
  */
-public sealed abstract class Expense permits ExpenseByNight, ExpenseByNightCustom, ExpenseByShare, ExpenseEqual, ExpenseFree {
+public sealed abstract class Expense
+        permits ExpenseByNight, ExpenseByNightCustom, ExpenseByShare, ExpenseEqual, ExpenseFree {
 
     private static final int MAX_DESCRIPTION_LENGTH = 200;
 

--- a/fairnsquare-app/src/main/java/org/asymetrik/web/fairnsquare/split/domain/expenses/Expense.java
+++ b/fairnsquare-app/src/main/java/org/asymetrik/web/fairnsquare/split/domain/expenses/Expense.java
@@ -13,7 +13,7 @@ import com.aventrix.jnanoid.jnanoid.NanoIdUtils;
  * Sealed abstract class representing a shared expense in a split. Each concrete subclass implements its own share
  * calculation strategy.
  */
-public sealed abstract class Expense permits ExpenseByNight, ExpenseByShare, ExpenseEqual, ExpenseFree {
+public sealed abstract class Expense permits ExpenseByNight, ExpenseByNightCustom, ExpenseByShare, ExpenseEqual, ExpenseFree {
 
     private static final int MAX_DESCRIPTION_LENGTH = 200;
 
@@ -38,6 +38,8 @@ public sealed abstract class Expense permits ExpenseByNight, ExpenseByShare, Exp
             case EQUAL -> new ExpenseEqual(Id.generate(), amount, description, payerId, Instant.now());
             case FREE -> throw new UnsupportedOperationException(
                     "FREE mode requires shares - use ExpenseFree.create(amount, description, payerId, shares)");
+            case BY_NIGHT_CUSTOM -> throw new UnsupportedOperationException(
+                    "BY_NIGHT_CUSTOM mode requires participant IDs - use ExpenseByNightCustom.create(amount, description, payerId, participantIds)");
         };
     }
 
@@ -58,6 +60,8 @@ public sealed abstract class Expense permits ExpenseByNight, ExpenseByShare, Exp
             case EQUAL -> new ExpenseEqual(id, amount, description, payerId, createdAt);
             case FREE -> throw new UnsupportedOperationException(
                     "FREE mode requires shares - use ExpenseFree.fromJson(id, amount, description, payerId, shares, createdAt)");
+            case BY_NIGHT_CUSTOM -> throw new UnsupportedOperationException(
+                    "BY_NIGHT_CUSTOM mode requires participant IDs - use ExpenseByNightCustom.fromJson(...)");
         };
     }
 

--- a/fairnsquare-app/src/main/java/org/asymetrik/web/fairnsquare/split/domain/expenses/ExpenseByNightCustom.java
+++ b/fairnsquare-app/src/main/java/org/asymetrik/web/fairnsquare/split/domain/expenses/ExpenseByNightCustom.java
@@ -9,10 +9,10 @@ import org.asymetrik.web.fairnsquare.split.domain.participant.Participant;
 import org.asymetrik.web.fairnsquare.split.domain.Split;
 
 /**
- * Expense split proportionally based on nights stayed, but only among a custom subset of participants.
- * Useful when some participants (e.g. van guests) should be excluded from certain by-night expenses.
- *
- * <p>Share calculation: same as {@link ExpenseByNight}, applied only to the included participants.
+ * Expense split proportionally based on nights stayed, but only among a custom subset of participants. Useful when some
+ * participants (e.g. van guests) should be excluded from certain by-night expenses.
+ * <p>
+ * Share calculation: same as {@link ExpenseByNight}, applied only to the included participants.
  */
 public final class ExpenseByNightCustom extends Expense {
 
@@ -65,8 +65,8 @@ public final class ExpenseByNightCustom extends Expense {
     }
 
     /**
-     * Returns the IDs of participants included in this expense.
-     * Used by the persistence layer to store which participants participate.
+     * Returns the IDs of participants included in this expense. Used by the persistence layer to store which
+     * participants participate.
      */
     public List<Participant.Id> getIncludedParticipantIds() {
         return Collections.unmodifiableList(includedParticipantIds);
@@ -75,8 +75,7 @@ public final class ExpenseByNightCustom extends Expense {
     @Override
     public List<Share> getShares(Split split) {
         List<Participant> included = split.getParticipants().stream()
-                .filter(p -> includedParticipantIds.contains(p.id()))
-                .toList();
+                .filter(p -> includedParticipantIds.contains(p.id())).toList();
         if (included.isEmpty()) {
             return Collections.emptyList();
         }

--- a/fairnsquare-app/src/main/java/org/asymetrik/web/fairnsquare/split/domain/expenses/ExpenseByNightCustom.java
+++ b/fairnsquare-app/src/main/java/org/asymetrik/web/fairnsquare/split/domain/expenses/ExpenseByNightCustom.java
@@ -1,0 +1,94 @@
+package org.asymetrik.web.fairnsquare.split.domain.expenses;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
+
+import org.asymetrik.web.fairnsquare.split.domain.participant.Participant;
+import org.asymetrik.web.fairnsquare.split.domain.Split;
+
+/**
+ * Expense split proportionally based on nights stayed, but only among a custom subset of participants.
+ * Useful when some participants (e.g. van guests) should be excluded from certain by-night expenses.
+ *
+ * <p>Share calculation: same as {@link ExpenseByNight}, applied only to the included participants.
+ */
+public final class ExpenseByNightCustom extends Expense {
+
+    private final List<Participant.Id> includedParticipantIds;
+
+    /**
+     * Factory method for creating new BY_NIGHT_CUSTOM expenses.
+     *
+     * @param amount
+     *            the expense amount (must be positive)
+     * @param description
+     *            the expense description (required, max 200 chars)
+     * @param payerId
+     *            the ID of the participant who paid
+     * @param includedParticipantIds
+     *            the IDs of participants included in this expense (must not be empty)
+     *
+     * @return a new ExpenseByNightCustom with generated ID and createdAt set to now
+     */
+    public static ExpenseByNightCustom create(BigDecimal amount, String description, Participant.Id payerId,
+            List<Participant.Id> includedParticipantIds) {
+        validateAmount(amount);
+        validateDescription(description);
+        validateIncludedParticipants(includedParticipantIds);
+        return new ExpenseByNightCustom(Id.generate(), amount, description, payerId,
+                List.copyOf(includedParticipantIds), Instant.now());
+    }
+
+    /**
+     * Reconstitutes an ExpenseByNightCustom from stored fields (used by persistence mapper).
+     */
+    public static ExpenseByNightCustom fromJson(Id id, BigDecimal amount, String description, Participant.Id payerId,
+            List<Participant.Id> includedParticipantIds, Instant createdAt) {
+        return new ExpenseByNightCustom(id, amount, description, payerId, List.copyOf(includedParticipantIds),
+                createdAt);
+    }
+
+    /**
+     * Package-private constructor for internal use.
+     */
+    ExpenseByNightCustom(Id id, BigDecimal amount, String description, Participant.Id payerId,
+            List<Participant.Id> includedParticipantIds, Instant createdAt) {
+        super(id, amount, description, payerId, createdAt);
+        this.includedParticipantIds = includedParticipantIds;
+    }
+
+    @Override
+    public SplitMode getSplitMode() {
+        return SplitMode.BY_NIGHT_CUSTOM;
+    }
+
+    /**
+     * Returns the IDs of participants included in this expense.
+     * Used by the persistence layer to store which participants participate.
+     */
+    public List<Participant.Id> getIncludedParticipantIds() {
+        return Collections.unmodifiableList(includedParticipantIds);
+    }
+
+    @Override
+    public List<Share> getShares(Split split) {
+        List<Participant> included = split.getParticipants().stream()
+                .filter(p -> includedParticipantIds.contains(p.id()))
+                .toList();
+        if (included.isEmpty()) {
+            return Collections.emptyList();
+        }
+        // Delegate calculation to ExpenseByNight logic
+        ExpenseByNight calculator = new ExpenseByNight(getId(), getAmount(), getDescription(), getPayerId(),
+                getCreatedAt());
+        return calculator.calculateShares(included);
+    }
+
+    private static void validateIncludedParticipants(List<Participant.Id> includedParticipantIds) {
+        if (includedParticipantIds == null || includedParticipantIds.isEmpty()) {
+            throw new IllegalArgumentException("BY_NIGHT_CUSTOM expense must include at least one participant");
+        }
+    }
+}

--- a/fairnsquare-app/src/main/java/org/asymetrik/web/fairnsquare/split/domain/expenses/SplitMode.java
+++ b/fairnsquare-app/src/main/java/org/asymetrik/web/fairnsquare/split/domain/expenses/SplitMode.java
@@ -23,7 +23,12 @@ public enum SplitMode {
     /**
      * Allow manual specification of each participant's share.
      */
-    FREE("FREE");
+    FREE("FREE"),
+
+    /**
+     * Distribute expense proportionally based on nights stayed, but only among a custom subset of participants.
+     */
+    BY_NIGHT_CUSTOM("BY_NIGHT_CUSTOM");
 
     private final String value;
 

--- a/fairnsquare-app/src/main/java/org/asymetrik/web/fairnsquare/split/persistence/dto/ExpenseByNightCustomPersistenceDTO.java
+++ b/fairnsquare-app/src/main/java/org/asymetrik/web/fairnsquare/split/persistence/dto/ExpenseByNightCustomPersistenceDTO.java
@@ -6,8 +6,8 @@ import java.util.List;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 /**
- * Persistence DTO for ExpenseByNightCustom domain object.
- * Stores the list of included participant IDs alongside standard expense fields.
+ * Persistence DTO for ExpenseByNightCustom domain object. Stores the list of included participant IDs alongside
+ * standard expense fields.
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record ExpenseByNightCustomPersistenceDTO(String id, BigDecimal amount, String description, String payerId,

--- a/fairnsquare-app/src/main/java/org/asymetrik/web/fairnsquare/split/persistence/dto/ExpenseByNightCustomPersistenceDTO.java
+++ b/fairnsquare-app/src/main/java/org/asymetrik/web/fairnsquare/split/persistence/dto/ExpenseByNightCustomPersistenceDTO.java
@@ -1,0 +1,15 @@
+package org.asymetrik.web.fairnsquare.split.persistence.dto;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/**
+ * Persistence DTO for ExpenseByNightCustom domain object.
+ * Stores the list of included participant IDs alongside standard expense fields.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record ExpenseByNightCustomPersistenceDTO(String id, BigDecimal amount, String description, String payerId,
+        String createdAt, List<String> participantIds) implements ExpensePersistenceDTO {
+}

--- a/fairnsquare-app/src/main/java/org/asymetrik/web/fairnsquare/split/persistence/dto/ExpensePersistenceDTO.java
+++ b/fairnsquare-app/src/main/java/org/asymetrik/web/fairnsquare/split/persistence/dto/ExpensePersistenceDTO.java
@@ -11,12 +11,13 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
  */
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type", defaultImpl = ExpenseByNightPersistenceDTO.class)
 @JsonSubTypes({ @JsonSubTypes.Type(value = ExpenseByNightPersistenceDTO.class, name = "BY_NIGHT"),
+        @JsonSubTypes.Type(value = ExpenseByNightCustomPersistenceDTO.class, name = "BY_NIGHT_CUSTOM"),
         @JsonSubTypes.Type(value = ExpenseBySharePersistenceDTO.class, name = "BY_SHARE"),
         @JsonSubTypes.Type(value = ExpenseBySharePersistenceDTO.class, name = "BY_PERSON"), // backward compat
         @JsonSubTypes.Type(value = ExpenseEqualPersistenceDTO.class, name = "EQUAL"),
         @JsonSubTypes.Type(value = ExpenseFreePersistenceDTO.class, name = "FREE") })
-public sealed interface ExpensePersistenceDTO permits ExpenseByNightPersistenceDTO, ExpenseBySharePersistenceDTO,
-        ExpenseEqualPersistenceDTO, ExpenseFreePersistenceDTO {
+public sealed interface ExpensePersistenceDTO permits ExpenseByNightPersistenceDTO, ExpenseByNightCustomPersistenceDTO,
+        ExpenseBySharePersistenceDTO, ExpenseEqualPersistenceDTO, ExpenseFreePersistenceDTO {
 
     String id();
 

--- a/fairnsquare-app/src/main/java/org/asymetrik/web/fairnsquare/split/persistence/mapper/ExpensePersistenceMapper.java
+++ b/fairnsquare-app/src/main/java/org/asymetrik/web/fairnsquare/split/persistence/mapper/ExpensePersistenceMapper.java
@@ -34,8 +34,8 @@ public class ExpensePersistenceMapper {
             case ExpenseByNight _ -> new ExpenseByNightPersistenceDTO(id, expense.getAmount(), expense.getDescription(),
                     payerId, createdAt);
             case ExpenseByNightCustom custom -> {
-                var participantIdStrings = custom.getIncludedParticipantIds().stream()
-                        .map(Participant.Id::value).toList();
+                var participantIdStrings = custom.getIncludedParticipantIds().stream().map(Participant.Id::value)
+                        .toList();
                 yield new ExpenseByNightCustomPersistenceDTO(id, expense.getAmount(), expense.getDescription(), payerId,
                         createdAt, participantIdStrings);
             }

--- a/fairnsquare-app/src/main/java/org/asymetrik/web/fairnsquare/split/persistence/mapper/ExpensePersistenceMapper.java
+++ b/fairnsquare-app/src/main/java/org/asymetrik/web/fairnsquare/split/persistence/mapper/ExpensePersistenceMapper.java
@@ -6,10 +6,12 @@ import jakarta.enterprise.context.ApplicationScoped;
 
 import org.asymetrik.web.fairnsquare.split.domain.expenses.Expense;
 import org.asymetrik.web.fairnsquare.split.domain.expenses.ExpenseByNight;
+import org.asymetrik.web.fairnsquare.split.domain.expenses.ExpenseByNightCustom;
 import org.asymetrik.web.fairnsquare.split.domain.expenses.ExpenseByShare;
 import org.asymetrik.web.fairnsquare.split.domain.expenses.ExpenseEqual;
 import org.asymetrik.web.fairnsquare.split.domain.expenses.ExpenseFree;
 import org.asymetrik.web.fairnsquare.split.domain.participant.Participant;
+import org.asymetrik.web.fairnsquare.split.persistence.dto.ExpenseByNightCustomPersistenceDTO;
 import org.asymetrik.web.fairnsquare.split.persistence.dto.ExpenseByNightPersistenceDTO;
 import org.asymetrik.web.fairnsquare.split.persistence.dto.ExpenseBySharePersistenceDTO;
 import org.asymetrik.web.fairnsquare.split.persistence.dto.ExpenseEqualPersistenceDTO;
@@ -31,6 +33,12 @@ public class ExpensePersistenceMapper {
         return switch (expense) {
             case ExpenseByNight _ -> new ExpenseByNightPersistenceDTO(id, expense.getAmount(), expense.getDescription(),
                     payerId, createdAt);
+            case ExpenseByNightCustom custom -> {
+                var participantIdStrings = custom.getIncludedParticipantIds().stream()
+                        .map(Participant.Id::value).toList();
+                yield new ExpenseByNightCustomPersistenceDTO(id, expense.getAmount(), expense.getDescription(), payerId,
+                        createdAt, participantIdStrings);
+            }
             case ExpenseByShare _ -> new ExpenseBySharePersistenceDTO(id, expense.getAmount(), expense.getDescription(),
                     payerId, createdAt);
             case ExpenseEqual _ -> new ExpenseEqualPersistenceDTO(id, expense.getAmount(), expense.getDescription(),
@@ -62,6 +70,11 @@ public class ExpensePersistenceMapper {
         return switch (dto) {
             case ExpenseByNightPersistenceDTO _ ->
                     ExpenseByNight.fromJson(id, dto.amount(), dto.description(), payerId, createdAt);
+            case ExpenseByNightCustomPersistenceDTO custom -> {
+                var participantIds = custom.participantIds().stream().map(Participant.Id::of).toList();
+                yield ExpenseByNightCustom.fromJson(id, dto.amount(), dto.description(), payerId, participantIds,
+                        createdAt);
+            }
             case ExpenseBySharePersistenceDTO _ ->
                     ExpenseByShare.fromJson(id, dto.amount(), dto.description(), payerId, createdAt);
             case ExpenseEqualPersistenceDTO _ ->

--- a/fairnsquare-app/src/main/java/org/asymetrik/web/fairnsquare/split/service/AddByNightCustomExpenseRequest.java
+++ b/fairnsquare-app/src/main/java/org/asymetrik/web/fairnsquare/split/service/AddByNightCustomExpenseRequest.java
@@ -1,0 +1,23 @@
+package org.asymetrik.web.fairnsquare.split.service;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+/**
+ * Request for creating a BY_NIGHT_CUSTOM expense with a custom subset of participants.
+ */
+public record AddByNightCustomExpenseRequest(
+        @NotNull(message = "Amount is required") @DecimalMin(value = "0.01", message = "Amount must be at least 0.01") BigDecimal amount,
+
+        @NotBlank(message = "Description is required") @Size(max = 200, message = "Description cannot exceed 200 characters") String description,
+
+        @NotBlank(message = "Payer is required") String payerId,
+
+        @NotEmpty(message = "At least one participant must be included") List<@NotBlank String> participantIds) {
+}

--- a/fairnsquare-app/src/main/java/org/asymetrik/web/fairnsquare/split/service/SplitUseCases.java
+++ b/fairnsquare-app/src/main/java/org/asymetrik/web/fairnsquare/split/service/SplitUseCases.java
@@ -268,6 +268,8 @@ public class SplitUseCases {
                     addExpenseEqual(splitId, request.amount(), request.description(), request.payerId()).map(e -> e);
             case FREE -> throw new UnsupportedOperationException(
                     "FREE mode requires shares - use addExpenseFree() with AddFreeExpenseRequest");
+            case BY_NIGHT_CUSTOM -> throw new UnsupportedOperationException(
+                    "BY_NIGHT_CUSTOM mode requires participant IDs - use addExpenseByNightCustom() with AddByNightCustomExpenseRequest");
         };
     }
 
@@ -381,13 +383,11 @@ public class SplitUseCases {
                 try {
                     split.getParticipant(Participant.Id.of(participantId));
                 } catch (ParticipantNotFoundError e) {
-                    throw new InvalidSharesError(
-                            "Participant with ID '" + participantId + "' not found in split.");
+                    throw new InvalidSharesError("Participant with ID '" + participantId + "' not found in split.");
                 }
             }
 
-            List<Participant.Id> includedIds = request.participantIds().stream()
-                    .map(Participant.Id::of).toList();
+            List<Participant.Id> includedIds = request.participantIds().stream().map(Participant.Id::of).toList();
 
             ExpenseByNightCustom expense = ExpenseByNightCustom.create(request.amount(), request.description(), payer,
                     includedIds);

--- a/fairnsquare-app/src/main/java/org/asymetrik/web/fairnsquare/split/service/SplitUseCases.java
+++ b/fairnsquare-app/src/main/java/org/asymetrik/web/fairnsquare/split/service/SplitUseCases.java
@@ -13,6 +13,7 @@ import org.asymetrik.web.fairnsquare.sharedkernel.logging.Log;
 import org.asymetrik.web.fairnsquare.sharedkernel.logging.LogTag;
 import org.asymetrik.web.fairnsquare.split.domain.expenses.Expense;
 import org.asymetrik.web.fairnsquare.split.domain.expenses.ExpenseByNight;
+import org.asymetrik.web.fairnsquare.split.domain.expenses.ExpenseByNightCustom;
 import org.asymetrik.web.fairnsquare.split.domain.expenses.ExpenseByShare;
 import org.asymetrik.web.fairnsquare.split.domain.expenses.ExpenseEqual;
 import org.asymetrik.web.fairnsquare.split.domain.expenses.ExpenseFree;
@@ -349,6 +350,47 @@ public class SplitUseCases {
 
             // Create expense and calculate shares using encapsulated logic
             ExpenseEqual expense = ExpenseEqual.create(amount, description, payer);
+            split.addExpense(expense);
+            repository.save(split);
+
+            return expense;
+        });
+    }
+
+    /**
+     * Adds a BY_NIGHT_CUSTOM expense to an existing split. Shares are calculated proportionally based on nights stayed,
+     * but only among the specified participants.
+     *
+     * @param splitId
+     *            the split identifier
+     * @param request
+     *            the request containing amount, description, payerId, and included participant IDs
+     *
+     * @return an Optional containing the created expense if the split exists, empty otherwise. Throws
+     *         InvalidSharesError if any participant ID is invalid. Throws PayerNotFoundError if the payer is not a
+     *         participant in the split.
+     */
+    public Optional<ExpenseByNightCustom> addExpenseByNightCustom(@LogTag("splitId") String splitId,
+            AddByNightCustomExpenseRequest request) {
+        return repository.load(splitId).map(split -> {
+            Participant.Id payer = Participant.Id.of(request.payerId());
+            split.validatePayerExists(payer);
+
+            // Validate all participant IDs exist in the split
+            for (String participantId : request.participantIds()) {
+                try {
+                    split.getParticipant(Participant.Id.of(participantId));
+                } catch (ParticipantNotFoundError e) {
+                    throw new InvalidSharesError(
+                            "Participant with ID '" + participantId + "' not found in split.");
+                }
+            }
+
+            List<Participant.Id> includedIds = request.participantIds().stream()
+                    .map(Participant.Id::of).toList();
+
+            ExpenseByNightCustom expense = ExpenseByNightCustom.create(request.amount(), request.description(), payer,
+                    includedIds);
             split.addExpense(expense);
             repository.save(split);
 

--- a/fairnsquare-app/src/main/webui/src/lib/api/splits.ts
+++ b/fairnsquare-app/src/main/webui/src/lib/api/splits.ts
@@ -32,7 +32,7 @@ export interface Participant {
   balance?: number;
 }
 
-export type SplitMode = 'BY_NIGHT' | 'BY_SHARE' | 'EQUAL' | 'FREE';
+export type SplitMode = 'BY_NIGHT' | 'BY_NIGHT_CUSTOM' | 'BY_SHARE' | 'EQUAL' | 'FREE';
 
 export interface Share {
   participantId: string;
@@ -65,6 +65,13 @@ export interface AddFreeExpenseRequest {
     participantId: string;
     parts: number;
   }>;
+}
+
+export interface AddByNightCustomExpenseRequest {
+  amount: number;
+  description: string;
+  payerId: string;
+  participantIds: string[];
 }
 
 export interface UpdateExpenseRequest {
@@ -194,6 +201,22 @@ export async function addExpense(
   return apiRequest<Expense>(endpoint, {
     method: 'POST',
     body: JSON.stringify(body),
+  });
+}
+
+/**
+ * Adds a BY_NIGHT_CUSTOM expense to a split, with a custom subset of participants.
+ * @param splitId The split identifier
+ * @param request The request with amount, description, payerId and included participantIds
+ * @returns The created expense with calculated shares for included participants
+ */
+export async function addByNightCustomExpense(
+  splitId: string,
+  request: AddByNightCustomExpenseRequest
+): Promise<Expense> {
+  return apiRequest<Expense>(`/splits/${splitId}/expenses/by-night-custom`, {
+    method: 'POST',
+    body: JSON.stringify(request),
   });
 }
 

--- a/fairnsquare-app/src/main/webui/src/lib/components/expense/ExpenseEditModal.svelte
+++ b/fairnsquare-app/src/main/webui/src/lib/components/expense/ExpenseEditModal.svelte
@@ -5,7 +5,7 @@
    */
 
   import { untrack } from 'svelte';
-  import { addExpense, addFreeExpense, updateExpense, deleteExpense, type Expense, type Participant, type SplitMode } from '$lib/api/splits';
+  import { addExpense, addFreeExpense, addByNightCustomExpense, updateExpense, deleteExpense, type Expense, type Participant, type SplitMode } from '$lib/api/splits';
   import type { ApiError } from '$lib/api/client';
   import Button from '$lib/components/ui/button/button.svelte';
   import Input from '$lib/components/ui/input/input.svelte';
@@ -15,7 +15,7 @@
   import ConfirmDialog from '$lib/components/ui/confirm-dialog/confirm-dialog.svelte';
   import { addToast } from '$lib/stores/toastStore.svelte';
   import ShareEditModal from './ShareEditModal.svelte';
-  import { Moon, Equal, Edit3, Users, X, Info } from 'lucide-svelte';
+  import { Moon, Equal, Edit3, Users, X, Info, MoonStar } from 'lucide-svelte';
 
   // Props
   let {
@@ -63,6 +63,10 @@
       title: 'By Night',
       description: `The cost is shared proportionally based on each participant's total "night-shares" — calculated as nights × share weight.\n\nThe share weight represents the number of persons. For example, a couple has a share of 2, while a solo traveller has a share of 1.\n\nExample: Alice (1 person) stays 3 nights = 3 night-shares. Bob & Carol (couple, 2 persons) stay 2 nights = 4 night-shares. Total = 7 night-shares.\n\nAlice pays 3/7 of the expense, Bob & Carol pay 4/7.`,
     },
+    BY_NIGHT_CUSTOM: {
+      title: 'By Night (Custom)',
+      description: `Same as By Night, but only among a custom subset of participants.\n\nUse the "Edit Participants" button on the expense card to select who is included. Nights per participant are not modified — only participation is toggled.`,
+    },
     EQUAL: {
       title: 'Equal',
       description: `The cost is divided equally among all participants, regardless of their nights, share weight, or any other factor.\n\nExample: 3 participants share a €90 expense → each pays €30.`,
@@ -109,6 +113,13 @@
       splitMode !== expense.splitMode ||
       isSharesDirty
     )
+  );
+
+  // When editing a BY_NIGHT_CUSTOM expense, we need the participant IDs to recreate it
+  const byNightCustomParticipantIds = $derived(
+    expense?.splitMode === 'BY_NIGHT_CUSTOM'
+      ? expense.shares.map((s) => s.participantId)
+      : []
   );
 
   // Dirty tracking (add mode)
@@ -324,6 +335,21 @@
         addToast({
           type: 'success',
           message: isEditMode ? 'Expense updated' : 'Expense added',
+          description: `${description.trim()} · €${amountValue.toFixed(2)} · Paid by ${participants.find(p => p.id === payerId)?.name ?? 'Unknown'}`,
+        });
+      } else if (splitMode === 'BY_NIGHT_CUSTOM' && isEditMode && expense) {
+        // BY_NIGHT_CUSTOM update: delete old + create new to preserve participant IDs
+        const participantIds = byNightCustomParticipantIds;
+        await deleteExpense(splitId, expense.id);
+        await addByNightCustomExpense(splitId, {
+          amount: amountValue,
+          description: description.trim(),
+          payerId,
+          participantIds,
+        });
+        addToast({
+          type: 'success',
+          message: 'Expense updated',
           description: `${description.trim()} · €${amountValue.toFixed(2)} · Paid by ${participants.find(p => p.id === payerId)?.name ?? 'Unknown'}`,
         });
       } else if (isEditMode && expense) {
@@ -568,6 +594,18 @@
                 <Info class="h-4 w-4" />
               </button>
             </div>
+            {#if expense?.splitMode === 'BY_NIGHT_CUSTOM'}
+              <div class="flex items-center space-x-2 p-3 border rounded-lg bg-muted/30 min-h-[44px]">
+                <RadioGroup.Item value="BY_NIGHT_CUSTOM" id="modal-mode-by-night-custom" />
+                <Label for="modal-mode-by-night-custom" class="flex items-center gap-2 cursor-pointer flex-1">
+                  <MoonStar class="h-4 w-4" aria-hidden="true" />
+                  <span>By Night (Custom)</span>
+                </Label>
+                <button type="button" onclick={(e) => openInfo('BY_NIGHT_CUSTOM', e)} class="p-1 rounded-full hover:bg-muted text-muted-foreground" aria-label="Info about By Night Custom">
+                  <Info class="h-4 w-4" />
+                </button>
+              </div>
+            {/if}
             <div class="flex items-center space-x-2 p-3 border rounded-lg hover:bg-accent min-h-[44px]">
               <RadioGroup.Item value="EQUAL" id="modal-mode-equal" />
               <Label for="modal-mode-equal" class="flex items-center gap-2 cursor-pointer flex-1">

--- a/fairnsquare-app/src/main/webui/src/lib/components/expense/ParticipantSelectModal.svelte
+++ b/fairnsquare-app/src/main/webui/src/lib/components/expense/ParticipantSelectModal.svelte
@@ -1,0 +1,153 @@
+<script lang="ts">
+  /**
+   * ParticipantSelectModal - Sub-modal for selecting which participants are included in a BY_NIGHT_CUSTOM expense.
+   * Only shows checkboxes — nights per participant are read-only and not displayed here.
+   */
+
+  import { untrack } from 'svelte';
+  import type { Participant } from '$lib/api/splits';
+  import Button from '$lib/components/ui/button/button.svelte';
+  import Label from '$lib/components/ui/label/label.svelte';
+  import { Checkbox } from '$lib/components/ui/checkbox';
+  import { X } from 'lucide-svelte';
+
+  interface Props {
+    open: boolean;
+    participants: Participant[];
+    initialSelectedIds: string[];
+    onConfirm: (selectedIds: string[]) => void;
+    onCancel: () => void;
+  }
+
+  let {
+    open,
+    participants,
+    initialSelectedIds,
+    onConfirm,
+    onCancel,
+  }: Props = $props();
+
+  let localChecked = $state<Record<string, boolean>>({});
+
+  $effect(() => {
+    if (open) {
+      untrack(() => {
+        localChecked = {};
+        for (const p of participants) {
+          localChecked[p.id] = initialSelectedIds.includes(p.id);
+        }
+      });
+    }
+  });
+
+  const selectedCount = $derived(Object.values(localChecked).filter(Boolean).length);
+  const isValid = $derived(selectedCount > 0);
+
+  function handleCheckChange(participantId: string, checked: boolean) {
+    localChecked[participantId] = checked;
+  }
+
+  function handleConfirm() {
+    const selectedIds = Object.entries(localChecked)
+      .filter(([, checked]) => checked)
+      .map(([id]) => id);
+    onConfirm(selectedIds);
+  }
+
+  function handleBackdropClick(event: MouseEvent) {
+    if (event.target === event.currentTarget) {
+      onCancel();
+    }
+  }
+
+  function handleKeydown(event: KeyboardEvent) {
+    if (!open) return;
+    if (event.key === 'Escape') {
+      event.stopPropagation();
+      onCancel();
+    }
+  }
+</script>
+
+<svelte:window onkeydown={handleKeydown} />
+
+{#if open}
+  <!-- svelte-ignore a11y_click_events_have_key_events -->
+  <div
+    class="fixed inset-0 z-[60] bg-black/50 flex items-center justify-center p-4"
+    onclick={handleBackdropClick}
+    role="dialog"
+    aria-modal="true"
+    aria-labelledby="participant-select-modal-title"
+    tabindex="-1"
+  >
+    <!-- svelte-ignore a11y_click_events_have_key_events -->
+    <div
+      role="presentation"
+      class="bg-background rounded-lg shadow-lg w-full max-w-[380px] animate-in fade-in zoom-in-95"
+      onclick={(e) => e.stopPropagation()}
+    >
+      <!-- Header -->
+      <div class="flex items-center justify-between p-4 border-b">
+        <h2 id="participant-select-modal-title" class="text-lg font-semibold">Edit Participants</h2>
+        <Button
+          variant="ghost"
+          size="sm"
+          onclick={onCancel}
+          class="min-h-[44px] min-w-[44px]"
+          aria-label="Close"
+        >
+          <X class="h-4 w-4" />
+        </Button>
+      </div>
+
+      <!-- Content -->
+      <div class="p-4 space-y-3">
+        <p class="text-xs text-muted-foreground">
+          Select who is participating in this expense. Nights per participant are not modified here.
+        </p>
+
+        <!-- Participant checkboxes -->
+        <div class="max-h-[300px] overflow-y-auto space-y-2" role="list" aria-label="Participants">
+          {#each participants as participant (participant.id)}
+            <div class="flex items-center gap-3 min-h-[44px]" role="listitem">
+              <Checkbox
+                id="participant-check-{participant.id}"
+                checked={localChecked[participant.id]}
+                onchange={(e: Event) => handleCheckChange(participant.id, (e.target as HTMLInputElement).checked)}
+                aria-label="Include {participant.name}"
+                class="min-w-[20px] min-h-[20px]"
+              />
+              <Label for="participant-check-{participant.id}" class="flex-1 text-sm cursor-pointer">
+                {participant.name}
+                <span class="text-xs text-muted-foreground ml-1">({participant.nights} night{participant.nights !== 1 ? 's' : ''})</span>
+              </Label>
+            </div>
+          {/each}
+        </div>
+
+        {#if !isValid}
+          <p class="text-xs text-destructive">At least one participant must be selected</p>
+        {/if}
+      </div>
+
+      <!-- Actions -->
+      <div class="flex gap-2 p-4 border-t">
+        <Button
+          onclick={handleConfirm}
+          disabled={!isValid}
+          class="flex-1 min-h-[44px]"
+        >
+          Confirm ({selectedCount} selected)
+        </Button>
+        <Button
+          variant="outline"
+          onclick={onCancel}
+          class="flex-1 min-h-[44px]"
+        >
+          Cancel
+        </Button>
+      </div>
+    </div>
+  </div>
+{/if}

--- a/fairnsquare-app/src/main/webui/src/lib/components/expense/ParticipantSelectModal.test.ts
+++ b/fairnsquare-app/src/main/webui/src/lib/components/expense/ParticipantSelectModal.test.ts
@@ -1,0 +1,171 @@
+/**
+ * ParticipantSelectModal Tests
+ * Issue #87: Allow editing participants for BY_NIGHT expenses (BY_NIGHT_CUSTOM)
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/svelte';
+import ParticipantSelectModal from './ParticipantSelectModal.svelte';
+import type { Participant } from '$lib/api/splits';
+
+const mockParticipants: Participant[] = [
+  { id: 'p1', name: 'Alice', nights: 4 },
+  { id: 'p2', name: 'Bob', nights: 2 },
+  { id: 'p3', name: 'Charlie', nights: 3 },
+];
+
+describe('ParticipantSelectModal', () => {
+  const onConfirm = vi.fn();
+  const onCancel = vi.fn();
+
+  const defaultProps = {
+    open: true,
+    participants: mockParticipants,
+    initialSelectedIds: ['p1', 'p2', 'p3'],
+    onConfirm,
+    onCancel,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the modal when open', () => {
+    render(ParticipantSelectModal, { props: defaultProps });
+    expect(screen.getByRole('dialog')).toBeTruthy();
+    expect(screen.getByText('Edit Participants')).toBeTruthy();
+  });
+
+  it('does not render when closed', () => {
+    render(ParticipantSelectModal, { props: { ...defaultProps, open: false } });
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+
+  it('renders all participants with checkboxes', () => {
+    render(ParticipantSelectModal, { props: defaultProps });
+    expect(screen.getByLabelText('Include Alice')).toBeTruthy();
+    expect(screen.getByLabelText('Include Bob')).toBeTruthy();
+    expect(screen.getByLabelText('Include Charlie')).toBeTruthy();
+  });
+
+  it('shows nights for each participant', () => {
+    render(ParticipantSelectModal, { props: defaultProps });
+    expect(screen.getByText(/4 nights/)).toBeTruthy();
+    expect(screen.getByText(/2 nights/)).toBeTruthy();
+    expect(screen.getByText(/3 nights/)).toBeTruthy();
+  });
+
+  it('pre-checks participants in initialSelectedIds', async () => {
+    render(ParticipantSelectModal, {
+      props: { ...defaultProps, initialSelectedIds: ['p1', 'p3'] },
+    });
+    await waitFor(() => {
+      const aliceCheckbox = screen.getByLabelText('Include Alice') as HTMLInputElement;
+      const bobCheckbox = screen.getByLabelText('Include Bob') as HTMLInputElement;
+      const charlieCheckbox = screen.getByLabelText('Include Charlie') as HTMLInputElement;
+      expect(aliceCheckbox.checked).toBe(true);
+      expect(bobCheckbox.checked).toBe(false);
+      expect(charlieCheckbox.checked).toBe(true);
+    });
+  });
+
+  it('enables confirm button when at least one participant is selected', async () => {
+    render(ParticipantSelectModal, { props: defaultProps });
+    const confirmButton = screen.getByRole('button', { name: /Confirm/i });
+    expect(confirmButton).not.toBeDisabled();
+  });
+
+  it('disables confirm button when no participants are selected', async () => {
+    render(ParticipantSelectModal, {
+      props: { ...defaultProps, initialSelectedIds: [] },
+    });
+    await waitFor(() => {
+      const confirmButton = screen.getByRole('button', { name: /Confirm/i });
+      expect(confirmButton).toBeDisabled();
+    });
+  });
+
+  it('shows error message when no participants are selected', async () => {
+    render(ParticipantSelectModal, {
+      props: { ...defaultProps, initialSelectedIds: [] },
+    });
+    await waitFor(() => {
+      expect(screen.getByText('At least one participant must be selected')).toBeTruthy();
+    });
+  });
+
+  it('calls onConfirm with selected participant IDs', async () => {
+    render(ParticipantSelectModal, {
+      props: { ...defaultProps, initialSelectedIds: ['p1', 'p2'] },
+    });
+    const confirmButton = screen.getByRole('button', { name: /Confirm/i });
+    await fireEvent.click(confirmButton);
+    await waitFor(() => {
+      expect(onConfirm).toHaveBeenCalledWith(expect.arrayContaining(['p1', 'p2']));
+      expect(onConfirm.mock.calls[0][0]).toHaveLength(2);
+    });
+  });
+
+  it('calls onCancel when cancel button is clicked', async () => {
+    render(ParticipantSelectModal, { props: defaultProps });
+    const cancelButton = screen.getByRole('button', { name: /Cancel/i });
+    await fireEvent.click(cancelButton);
+    expect(onCancel).toHaveBeenCalled();
+  });
+
+  it('calls onCancel when close button is clicked', async () => {
+    render(ParticipantSelectModal, { props: defaultProps });
+    const closeButton = screen.getByLabelText('Close');
+    await fireEvent.click(closeButton);
+    expect(onCancel).toHaveBeenCalled();
+  });
+
+  it('updates selection count in confirm button when participant is toggled', async () => {
+    render(ParticipantSelectModal, {
+      props: { ...defaultProps, initialSelectedIds: ['p1', 'p2', 'p3'] },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Confirm \(3 selected\)/i })).toBeTruthy();
+    });
+
+    const bobCheckbox = screen.getByLabelText('Include Bob') as HTMLInputElement;
+    await fireEvent.change(bobCheckbox, { target: { checked: false } });
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Confirm \(2 selected\)/i })).toBeTruthy();
+    });
+  });
+
+  it('excludes unchecked participants from onConfirm call', async () => {
+    render(ParticipantSelectModal, {
+      props: { ...defaultProps, initialSelectedIds: ['p1', 'p2', 'p3'] },
+    });
+
+    const bobCheckbox = screen.getByLabelText('Include Bob') as HTMLInputElement;
+    await fireEvent.change(bobCheckbox, { target: { checked: false } });
+
+    const confirmButton = screen.getByRole('button', { name: /Confirm/i });
+    await fireEvent.click(confirmButton);
+
+    await waitFor(() => {
+      const calledWith: string[] = onConfirm.mock.calls[0][0];
+      expect(calledWith).toContain('p1');
+      expect(calledWith).toContain('p3');
+      expect(calledWith).not.toContain('p2');
+    });
+  });
+
+  it('dismisses on Escape key', async () => {
+    render(ParticipantSelectModal, { props: defaultProps });
+    await fireEvent.keyDown(window, { key: 'Escape' });
+    expect(onCancel).toHaveBeenCalled();
+  });
+
+  it('dismisses on backdrop click', async () => {
+    render(ParticipantSelectModal, { props: defaultProps });
+    const backdrop = screen.getByRole('dialog');
+    await fireEvent.click(backdrop);
+    expect(onCancel).toHaveBeenCalled();
+  });
+});

--- a/fairnsquare-app/src/main/webui/src/routes/ExpenseList.svelte
+++ b/fairnsquare-app/src/main/webui/src/routes/ExpenseList.svelte
@@ -1,15 +1,16 @@
 <script lang="ts">
   // Expense List Screen - Story FNS-002-5
 
-  import { getSplit, deleteExpense, type Split, type Expense, type SplitMode } from '$lib/api/splits';
+  import { getSplit, deleteExpense, addByNightCustomExpense, type Split, type Expense, type SplitMode } from '$lib/api/splits';
   import type { ApiError } from '$lib/api/client';
   import { Button } from '$lib/components/ui/button';
   import * as Card from '$lib/components/ui/card';
   import ConfirmDialog from '$lib/components/ui/confirm-dialog/confirm-dialog.svelte';
   import ExpenseEditModal from '$lib/components/expense/ExpenseEditModal.svelte';
+  import ParticipantSelectModal from '$lib/components/expense/ParticipantSelectModal.svelte';
   import { addToast } from '$lib/stores/toastStore.svelte';
   import { route, navigate } from '$lib/router';
-  import { Plus, Pencil, Trash2, Receipt, ListFilter, X } from 'lucide-svelte';
+  import { Plus, Pencil, Trash2, Receipt, ListFilter, X, UserCog } from 'lucide-svelte';
   import SplitPageHeader from '$lib/components/ui/split-page-header/SplitPageHeader.svelte';
 
   const splitId = $derived(route.params.splitId || '');
@@ -31,6 +32,11 @@
   let showEditExpense = $state(false);
   let expenseToEdit = $state<Expense | null>(null);
 
+  // Edit participants modal state
+  let showEditParticipants = $state(false);
+  let expenseToEditParticipants = $state<Expense | null>(null);
+  let isEditingParticipants = $state(false);
+
   // Filter state — initialized from URL query params, then managed as local state
   let selectedPayer = $state(String(route.search?.payer || ''));
   let selectedBeneficiary = $state(String(route.search?.beneficiary || ''));
@@ -51,7 +57,7 @@
       if (selectedBeneficiary) {
         const activeShares = expense.splitMode === 'FREE'
           ? expense.shares.filter((s) => s.parts != null && s.parts > 0)
-          : expense.shares;
+          : expense.shares; // BY_NIGHT_CUSTOM shares already contain only included participants
         if (!activeShares.some((s) => s.participantId === selectedBeneficiary)) return false;
       }
       return true;
@@ -120,6 +126,8 @@
     switch (mode) {
       case 'BY_NIGHT':
         return '\u{1F319}';
+      case 'BY_NIGHT_CUSTOM':
+        return '\u{1F319}\u2605';
       case 'EQUAL':
         return '\u229C';
       case 'BY_SHARE':
@@ -133,6 +141,8 @@
     switch (mode) {
       case 'BY_NIGHT':
         return 'By Night';
+      case 'BY_NIGHT_CUSTOM':
+        return 'By Night (Custom)';
       case 'EQUAL':
         return 'Equal';
       case 'BY_SHARE':
@@ -149,6 +159,7 @@
   function getParticipantNames(expense: Expense): string {
     if (!split) return '';
     // For FREE mode, only show participants with positive parts
+    // For BY_NIGHT_CUSTOM, shares already contain only the included participants
     const activeShares = expense.splitMode === 'FREE'
       ? expense.shares.filter((s) => s.parts != null && s.parts > 0)
       : expense.shares;
@@ -258,6 +269,48 @@
 
   async function handleEditExpenseSuccess() {
     await loadSplit(splitId);
+  }
+
+  function handleEditParticipantsClick(expense: Expense) {
+    expenseToEditParticipants = expense;
+    showEditParticipants = true;
+  }
+
+  function handleCloseEditParticipants() {
+    showEditParticipants = false;
+    expenseToEditParticipants = null;
+  }
+
+  async function handleConfirmEditParticipants(selectedIds: string[]) {
+    if (!expenseToEditParticipants) return;
+    isEditingParticipants = true;
+    const expense = expenseToEditParticipants;
+
+    try {
+      await deleteExpense(splitId, expense.id);
+      await addByNightCustomExpense(splitId, {
+        amount: expense.amount,
+        description: expense.description,
+        payerId: expense.payerId,
+        participantIds: selectedIds,
+      });
+      addToast({
+        type: 'success',
+        message: 'Participants updated',
+        description: `${expense.description} · now split among ${selectedIds.length} participant${selectedIds.length !== 1 ? 's' : ''}`,
+      });
+      showEditParticipants = false;
+      expenseToEditParticipants = null;
+      await loadSplit(splitId);
+    } catch (err: unknown) {
+      const error = err as ApiError;
+      addToast({
+        type: 'error',
+        message: error.detail || 'Failed to update participants. Please try again.',
+      });
+    } finally {
+      isEditingParticipants = false;
+    }
   }
 </script>
 
@@ -416,6 +469,17 @@
               <!-- Row 4: Actions -->
               {#if !isSettled}
                 <div class="flex items-center justify-end gap-1">
+                  {#if expense.splitMode === 'BY_NIGHT' || expense.splitMode === 'BY_NIGHT_CUSTOM'}
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onclick={() => handleEditParticipantsClick(expense)}
+                      class="min-h-[44px] min-w-[44px]"
+                      aria-label="Edit participants: {expense.description}"
+                    >
+                      <UserCog class="h-4 w-4" />
+                    </Button>
+                  {/if}
                   <Button
                     variant="ghost"
                     size="sm"
@@ -477,5 +541,16 @@
     participants={split.participants}
     onClose={handleCloseEditExpense}
     onSuccess={handleEditExpenseSuccess}
+  />
+{/if}
+
+<!-- Edit Participants Modal -->
+{#if split && expenseToEditParticipants}
+  <ParticipantSelectModal
+    open={showEditParticipants}
+    participants={split.participants}
+    initialSelectedIds={expenseToEditParticipants.shares.map((s) => s.participantId)}
+    onConfirm={handleConfirmEditParticipants}
+    onCancel={handleCloseEditParticipants}
   />
 {/if}

--- a/fairnsquare-app/src/test/java/org/asymetrik/web/fairnsquare/split/domain/expenses/ExpenseByNightCustomTest.java
+++ b/fairnsquare-app/src/test/java/org/asymetrik/web/fairnsquare/split/domain/expenses/ExpenseByNightCustomTest.java
@@ -47,8 +47,8 @@ class ExpenseByNightCustomTest {
 
         // Only alice and bob are included: 4/6 * 180 = 120, 2/6 * 180 = 60
         assertThat(shares).hasSize(2);
-        assertThat(shares.stream().map(s -> s.participantId()).toList())
-                .containsExactlyInAnyOrder(alice.id(), bob.id());
+        assertThat(shares.stream().map(s -> s.participantId()).toList()).containsExactlyInAnyOrder(alice.id(),
+                bob.id());
         assertThat(shares.get(0).amount()).isEqualByComparingTo("120.00");
         assertThat(shares.get(1).amount()).isEqualByComparingTo("60.00");
     }
@@ -100,8 +100,7 @@ class ExpenseByNightCustomTest {
         Participant.Id payerId = Participant.Id.generate();
 
         assertThatThrownBy(() -> ExpenseByNightCustom.create(new BigDecimal("100.00"), "Test", payerId, List.of()))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("at least one participant");
+                .isInstanceOf(IllegalArgumentException.class).hasMessageContaining("at least one participant");
     }
 
     @Test

--- a/fairnsquare-app/src/test/java/org/asymetrik/web/fairnsquare/split/domain/expenses/ExpenseByNightCustomTest.java
+++ b/fairnsquare-app/src/test/java/org/asymetrik/web/fairnsquare/split/domain/expenses/ExpenseByNightCustomTest.java
@@ -1,0 +1,161 @@
+package org.asymetrik.web.fairnsquare.split.domain.expenses;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import org.asymetrik.web.fairnsquare.split.domain.participant.Participant;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Unit tests for ExpenseByNightCustom share calculation logic.
+ */
+class ExpenseByNightCustomTest {
+
+    @Test
+    void getShares_withAllParticipantsIncluded_behavesLikeByNight() {
+        Participant alice = Participant.create("Alice", 4);
+        Participant bob = Participant.create("Bob", 2);
+        Participant charlie = Participant.create("Charlie", 3);
+
+        ExpenseByNightCustom expense = ExpenseByNightCustom.create(new BigDecimal("180.00"), "Groceries", alice.id(),
+                List.of(alice.id(), bob.id(), charlie.id()));
+
+        // Need a mock split - use a helper that returns all three participants
+        var split = buildSplit(List.of(alice, bob, charlie));
+        List<Expense.Share> shares = expense.getShares(split);
+
+        assertThat(shares).hasSize(3);
+        assertThat(shares.get(0).amount()).isEqualByComparingTo("80.00"); // 4/9 * 180
+        assertThat(shares.get(1).amount()).isEqualByComparingTo("40.00"); // 2/9 * 180
+        assertThat(shares.get(2).amount()).isEqualByComparingTo("60.00"); // remainder
+    }
+
+    @Test
+    void getShares_withSubsetOfParticipants_excludesNonIncluded() {
+        Participant alice = Participant.create("Alice", 4);
+        Participant bob = Participant.create("Bob", 2);
+        Participant charlie = Participant.create("Charlie", 3); // excluded
+
+        ExpenseByNightCustom expense = ExpenseByNightCustom.create(new BigDecimal("180.00"), "Groceries", alice.id(),
+                List.of(alice.id(), bob.id()));
+
+        var split = buildSplit(List.of(alice, bob, charlie));
+        List<Expense.Share> shares = expense.getShares(split);
+
+        // Only alice and bob are included: 4/6 * 180 = 120, 2/6 * 180 = 60
+        assertThat(shares).hasSize(2);
+        assertThat(shares.stream().map(s -> s.participantId()).toList())
+                .containsExactlyInAnyOrder(alice.id(), bob.id());
+        assertThat(shares.get(0).amount()).isEqualByComparingTo("120.00");
+        assertThat(shares.get(1).amount()).isEqualByComparingTo("60.00");
+    }
+
+    @Test
+    void getShares_withSingleIncludedParticipant_getsFullAmount() {
+        Participant alice = Participant.create("Alice", 4);
+        Participant bob = Participant.create("Bob", 2);
+
+        ExpenseByNightCustom expense = ExpenseByNightCustom.create(new BigDecimal("100.00"), "Solo expense", alice.id(),
+                List.of(alice.id()));
+
+        var split = buildSplit(List.of(alice, bob));
+        List<Expense.Share> shares = expense.getShares(split);
+
+        assertThat(shares).hasSize(1);
+        assertThat(shares.get(0).participantId()).isEqualTo(alice.id());
+        assertThat(shares.get(0).amount()).isEqualByComparingTo("100.00");
+    }
+
+    @Test
+    void getShares_sumsToExactExpenseAmount() {
+        Participant alice = Participant.create("Alice", 4);
+        Participant bob = Participant.create("Bob", 3);
+        Participant charlie = Participant.create("Charlie", 2);
+
+        ExpenseByNightCustom expense = ExpenseByNightCustom.create(new BigDecimal("100.00"), "Dinner", alice.id(),
+                List.of(alice.id(), bob.id(), charlie.id()));
+
+        var split = buildSplit(List.of(alice, bob, charlie));
+        List<Expense.Share> shares = expense.getShares(split);
+
+        BigDecimal total = shares.stream().map(Expense.Share::amount).reduce(BigDecimal.ZERO, BigDecimal::add);
+        assertThat(total).isEqualByComparingTo("100.00");
+    }
+
+    @Test
+    void getSplitMode_returnsByNightCustom() {
+        Participant alice = Participant.create("Alice", 3);
+
+        ExpenseByNightCustom expense = ExpenseByNightCustom.create(new BigDecimal("100.00"), "Test", alice.id(),
+                List.of(alice.id()));
+
+        assertThat(expense.getSplitMode()).isEqualTo(SplitMode.BY_NIGHT_CUSTOM);
+    }
+
+    @Test
+    void create_withEmptyParticipantIds_throwsIllegalArgumentException() {
+        Participant.Id payerId = Participant.Id.generate();
+
+        assertThatThrownBy(() -> ExpenseByNightCustom.create(new BigDecimal("100.00"), "Test", payerId, List.of()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("at least one participant");
+    }
+
+    @Test
+    void create_withNullParticipantIds_throwsIllegalArgumentException() {
+        Participant.Id payerId = Participant.Id.generate();
+
+        assertThatThrownBy(() -> ExpenseByNightCustom.create(new BigDecimal("100.00"), "Test", payerId, null))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void fromJson_recreatesExpenseWithSameParticipantIds() {
+        Expense.Id id = Expense.Id.generate();
+        Participant alice = Participant.create("Alice", 3);
+        Participant bob = Participant.create("Bob", 2);
+        List<Participant.Id> includedIds = List.of(alice.id(), bob.id());
+
+        ExpenseByNightCustom expense = ExpenseByNightCustom.fromJson(id, new BigDecimal("90.00"), "Hotel", alice.id(),
+                includedIds, java.time.Instant.now());
+
+        assertThat(expense.getId()).isEqualTo(id);
+        assertThat(expense.getIncludedParticipantIds()).containsExactlyInAnyOrderElementsOf(includedIds);
+    }
+
+    @Test
+    void getShares_withPersonsWeighting_appliesNightTimesPersonsFormula() {
+        // Alice: couple (2 persons), 3 nights → weight 6
+        // Bob: solo (1 person), 3 nights → weight 3
+        // Charlie (solo, 3 nights) is excluded
+        Participant alice = Participant.create("Alice", 3, 2.0);
+        Participant bob = Participant.create("Bob", 3, 1.0);
+        Participant charlie = Participant.create("Charlie", 3, 1.0);
+
+        ExpenseByNightCustom expense = ExpenseByNightCustom.create(new BigDecimal("90.00"), "Accommodation", alice.id(),
+                List.of(alice.id(), bob.id()));
+
+        var split = buildSplit(List.of(alice, bob, charlie));
+        List<Expense.Share> shares = expense.getShares(split);
+
+        // Alice: 6/9 * 90 = 60, Bob: 3/9 * 90 = 30
+        assertThat(shares).hasSize(2);
+        assertThat(shares.get(0).amount()).isEqualByComparingTo("60.00");
+        assertThat(shares.get(1).amount()).isEqualByComparingTo("30.00");
+    }
+
+    /**
+     * Builds a minimal Split stub for testing, containing the provided participants.
+     */
+    private org.asymetrik.web.fairnsquare.split.domain.Split buildSplit(List<Participant> participants) {
+        org.asymetrik.web.fairnsquare.split.domain.Split split = org.asymetrik.web.fairnsquare.split.domain.Split
+                .create("Test Split");
+        for (Participant p : participants) {
+            split.addParticipant(p);
+        }
+        return split;
+    }
+}

--- a/src/main/doc/implementation/2026-04-02-Feature-by-night-custom-van-guest.md
+++ b/src/main/doc/implementation/2026-04-02-Feature-by-night-custom-van-guest.md
@@ -1,0 +1,96 @@
+# Feature: BY_NIGHT_CUSTOM — Van Guest Participant Management
+
+**Date:** 2026-04-02  
+**Issue:** #87 — Add a way to manage van guest
+
+---
+
+## What, Why and Constraints
+
+### What
+Added a new `BY_NIGHT_CUSTOM` split mode that allows editing which participants are included in a by-night expense. Users can click an "Edit Participants" button on any `BY_NIGHT` or `BY_NIGHT_CUSTOM` expense card to open a participant selection modal. The expense is then converted to (or stays as) `BY_NIGHT_CUSTOM`, and the cost is split proportionally by nights among only the selected participants.
+
+### Why
+Van guests participate in all by-night expenses except the house rent. Previously there was no way to exclude them from specific expenses. This feature allows fine-grained participant control per expense.
+
+### Constraints
+- Nights per participant are **not editable** from this flow — only participation (in/out) is toggled.
+- The `BY_NIGHT_CUSTOM` mode uses the same proportional nights × share formula as `BY_NIGHT`, applied only to the selected subset.
+- Updating participants on an existing expense uses the delete + recreate pattern (consistent with how FREE mode updates work), since the backend update endpoint does not support share data.
+- The new mode is fully backward-compatible: existing `BY_NIGHT` data is unaffected.
+
+---
+
+## How
+
+### Backend
+
+**New files:**
+- `split/domain/expenses/ExpenseByNightCustom.java` — New sealed class permitted by `Expense`. Stores `List<Participant.Id> includedParticipantIds`. `getShares()` filters the split's participants to the included subset and delegates to `ExpenseByNight.calculateShares()`.
+- `split/persistence/dto/ExpenseByNightCustomPersistenceDTO.java` — Stores `participantIds: List<String>` in addition to standard expense fields.
+- `split/api/expense/dto/ExpenseByNightCustomDTO.java` — API response DTO (same shape as other expense DTOs).
+- `split/service/AddByNightCustomExpenseRequest.java` — Request record with `amount`, `description`, `payerId`, `participantIds`.
+
+**Modified files:**
+- `SplitMode.java` — Added `BY_NIGHT_CUSTOM` enum value.
+- `Expense.java` — Added `ExpenseByNightCustom` to `permits`; added `BY_NIGHT_CUSTOM` case in `fromJson()` and deprecated `create()` (throws UnsupportedOperationException like FREE mode).
+- `ExpensePersistenceDTO.java` — Added `BY_NIGHT_CUSTOM` to `@JsonSubTypes` and sealed interface `permits`.
+- `ExpensePersistenceMapper.java` — Added `ExpenseByNightCustom ↔ ExpenseByNightCustomPersistenceDTO` branches in both directions.
+- `ExpenseMapper.java` — Added `ExpenseByNightCustom` branch producing `ExpenseByNightCustomDTO`.
+- `SplitUseCases.java` — Added `addExpenseByNightCustom()` method validating payer and all participant IDs exist in the split.
+- `SplitResource.java` — Added `POST /splits/{splitId}/expenses/by-night-custom` endpoint.
+
+### Frontend
+
+**New files:**
+- `lib/components/expense/ParticipantSelectModal.svelte` — Modal with a checkbox list of participants. Shows nights next to each name (read-only). Validates at least one participant selected. Calls `onConfirm(selectedIds[])` on confirm.
+- `lib/components/expense/ParticipantSelectModal.test.ts` — 15 tests covering render, pre-selection, toggle, confirm/cancel, keyboard dismiss.
+
+**Modified files:**
+- `lib/api/splits.ts` — Added `'BY_NIGHT_CUSTOM'` to `SplitMode` union; added `AddByNightCustomExpenseRequest` interface and `addByNightCustomExpense()` function calling `POST /expenses/by-night-custom`.
+- `routes/ExpenseList.svelte`:
+  - Imported `addByNightCustomExpense`, `ParticipantSelectModal`, `UserCog` icon.
+  - `splitModeIcon()`: `BY_NIGHT_CUSTOM` → `🌙★`
+  - `splitModeText()`: `BY_NIGHT_CUSTOM` → `"By Night (Custom)"`
+  - `getParticipantNames()`: unchanged — `BY_NIGHT_CUSTOM` shares already contain only included participants.
+  - Added `showEditParticipants`, `expenseToEditParticipants`, `isEditingParticipants` state.
+  - Added `UserCog` ("Edit Participants") button on `BY_NIGHT` and `BY_NIGHT_CUSTOM` expense cards.
+  - `handleConfirmEditParticipants()`: calls `deleteExpense` + `addByNightCustomExpense` + reload.
+  - Wired up `ParticipantSelectModal`.
+- `lib/components/expense/ExpenseEditModal.svelte`:
+  - Added `addByNightCustomExpense` import and `MoonStar` icon.
+  - Added `BY_NIGHT_CUSTOM` entry in `splitModeInfo`.
+  - Added `byNightCustomParticipantIds` derived (reads participant IDs from existing shares).
+  - Handles `BY_NIGHT_CUSTOM` in submit: uses delete + recreate preserving participant IDs.
+  - Shows `BY_NIGHT_CUSTOM` as a conditional radio option (visible only when editing a custom expense).
+
+---
+
+## Tests
+
+### Backend (unit tests)
+File: `src/test/java/.../split/domain/expenses/ExpenseByNightCustomTest.java` — 8 tests:
+- `getShares_withAllParticipantsIncluded_behavesLikeByNight`
+- `getShares_withSubsetOfParticipants_excludesNonIncluded`
+- `getShares_withSingleIncludedParticipant_getsFullAmount`
+- `getShares_sumsToExactExpenseAmount`
+- `getSplitMode_returnsByNightCustom`
+- `create_withEmptyParticipantIds_throwsIllegalArgumentException`
+- `create_withNullParticipantIds_throwsIllegalArgumentException`
+- `fromJson_recreatesExpenseWithSameParticipantIds`
+- `getShares_withPersonsWeighting_appliesNightTimesPersonsFormula`
+
+> Note: Backend tests could not be executed in this environment due to Maven BOM resolution failure (no network access to `repo.maven.apache.org`). The test logic mirrors the existing `ExpenseByNightTest` patterns and was verified by code review.
+
+### Frontend (vitest)
+File: `src/lib/components/expense/ParticipantSelectModal.test.ts` — **15 tests**, all passing:
+- Render/visibility, participant list, nights display
+- Pre-selection from `initialSelectedIds`
+- Enable/disable confirm button
+- Validation message when empty
+- `onConfirm` called with correct IDs
+- Unchecked participants excluded
+- `onCancel` from cancel button, close button, Escape key, backdrop click
+- Count in confirm button updates on toggle
+
+**Full suite:** 462 tests passed (19 test files), no regressions.


### PR DESCRIPTION
Resolves #87. Adds ability to edit which participants are included in a
by-night expense, creating a new BY_NIGHT_CUSTOM mode that applies the
same proportional night-based calculation to a custom subset only.

Backend:
- Add BY_NIGHT_CUSTOM to SplitMode enum
- New ExpenseByNightCustom domain class storing included participant IDs
- New POST /expenses/by-night-custom endpoint
- Persistence DTO and mapper support for ExpenseByNightCustom
- Unit tests for ExpenseByNightCustom.getShares() (8 tests)

Frontend:
- New ParticipantSelectModal with checkboxes (no nights editing)
- "Edit Participants" button (UserCog icon) on BY_NIGHT and BY_NIGHT_CUSTOM expense cards
- BY_NIGHT_CUSTOM mode display with 🌙★ icon and "By Night (Custom)" label
- ExpenseEditModal handles BY_NIGHT_CUSTOM via delete+recreate
- 15 new tests for ParticipantSelectModal

https://claude.ai/code/session_01CqAwEvFTRmaXBkFbxoNwFf