### PR TITLE
feat: add "Copy nights shares" shortcut in custom expense share editor (#87)

### DIFF
--- a/fairnsquare-app/src/main/webui/src/lib/components/expense/ShareEditModal.svelte
+++ b/fairnsquare-app/src/main/webui/src/lib/components/expense/ShareEditModal.svelte
@@ -11,7 +11,7 @@
   import Input from '$lib/components/ui/input/input.svelte';
   import Label from '$lib/components/ui/label/label.svelte';
   import { Checkbox } from '$lib/components/ui/checkbox';
-  import { X } from 'lucide-svelte';
+  import { X, Moon, AlertTriangle } from 'lucide-svelte';
 
   interface ShareData {
     shareParts: Record<string, number | ''>;
@@ -83,6 +83,26 @@
     });
   }
 
+  let showNightsWarning = $state(false);
+
+  function copyNightsShares() {
+    showNightsWarning = true;
+  }
+
+  function applyNightsShares() {
+    for (const participant of participants) {
+      const value = participant.nights * participant.share;
+      localParts[participant.id] = value;
+      localChecked[participant.id] = true;
+      localPreviousValues[participant.id] = value;
+    }
+    showNightsWarning = false;
+  }
+
+  function cancelNightsWarning() {
+    showNightsWarning = false;
+  }
+
   function handleBackdropClick(event: MouseEvent) {
     if (event.target === event.currentTarget) {
       onCancel();
@@ -140,6 +160,37 @@
             {localTotalParts.toFixed(2)} parts {isLocalPartsValid ? '✓' : '⚠'}
           </span>
         </div>
+
+        <Button
+          variant="outline"
+          size="sm"
+          onclick={copyNightsShares}
+          class="w-full min-h-[44px] gap-2"
+        >
+          <Moon class="h-4 w-4" />
+          Copy nights shares
+        </Button>
+
+        {#if showNightsWarning}
+          <div class="rounded-md border border-amber-300 bg-amber-50 p-3 space-y-2" role="alert">
+            <div class="flex items-start gap-2">
+              <AlertTriangle class="h-4 w-4 text-amber-600 mt-0.5 shrink-0" />
+              <p class="text-xs text-amber-800">
+                This will overwrite all current values with each participant's
+                <strong>nights × share</strong>. These values are a static snapshot — future
+                changes to nights or share will not be reflected here automatically.
+              </p>
+            </div>
+            <div class="flex gap-2">
+              <Button size="sm" onclick={applyNightsShares} class="flex-1 min-h-[36px]">
+                Apply
+              </Button>
+              <Button variant="outline" size="sm" onclick={cancelNightsWarning} class="flex-1 min-h-[36px]">
+                Cancel
+              </Button>
+            </div>
+          </div>
+        {/if}
 
         <!-- Scrollable participant list -->
         <div class="max-h-[300px] overflow-y-auto space-y-2" role="list" aria-label="Participant shares">

--- a/fairnsquare-app/src/main/webui/src/lib/components/expense/ShareEditModal.test.ts
+++ b/fairnsquare-app/src/main/webui/src/lib/components/expense/ShareEditModal.test.ts
@@ -1,0 +1,174 @@
+/**
+ * ShareEditModal Tests
+ * Issue #87: Copy nights shares in custom expense
+ *
+ * AC1: "Copy nights shares" button is rendered
+ * AC2: Clicking the button shows the warning banner
+ * AC3: Warning banner explains values will be overridden and not synchronized
+ * AC4: Cancelling the warning dismisses it without changing values
+ * AC5: Applying overwrites all parts with nights × share and checks all participants
+ * AC6: Applying closes the warning banner
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/svelte';
+import ShareEditModal from './ShareEditModal.svelte';
+import type { Participant } from '$lib/api/splits';
+
+const mockParticipants: Participant[] = [
+  { id: 'p1', name: 'Alice', nights: 3, share: 1 },
+  { id: 'p2', name: 'Bob', nights: 2, share: 2 },
+  { id: 'p3', name: 'Charlie', nights: 4, share: 1 },
+];
+
+const defaultInitialData = {
+  shareParts: { p1: 5, p2: 5, p3: 5 },
+  shareChecked: { p1: true, p2: true, p3: true },
+  sharePreviousValues: { p1: 5, p2: 5, p3: 5 },
+};
+
+const defaultProps = {
+  open: true,
+  participants: mockParticipants,
+  initialData: defaultInitialData,
+  onConfirm: vi.fn(),
+  onCancel: vi.fn(),
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('ShareEditModal – Copy nights shares (AC1)', () => {
+  it('renders the "Copy nights shares" button', () => {
+    render(ShareEditModal, { props: defaultProps });
+    expect(screen.getByRole('button', { name: /copy nights shares/i })).toBeInTheDocument();
+  });
+});
+
+describe('ShareEditModal – Copy nights shares (AC2)', () => {
+  it('clicking the button shows the warning banner', async () => {
+    render(ShareEditModal, { props: defaultProps });
+
+    fireEvent.click(screen.getByRole('button', { name: /copy nights shares/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toBeInTheDocument();
+    });
+  });
+
+  it('warning banner contains Apply and Cancel actions', async () => {
+    render(ShareEditModal, { props: defaultProps });
+
+    fireEvent.click(screen.getByRole('button', { name: /copy nights shares/i }));
+
+    await waitFor(() => {
+      const alert = screen.getByRole('alert');
+      expect(within(alert).getByRole('button', { name: /^apply$/i })).toBeInTheDocument();
+      expect(within(alert).getByRole('button', { name: /^cancel$/i })).toBeInTheDocument();
+    });
+  });
+});
+
+describe('ShareEditModal – Copy nights shares (AC3)', () => {
+  it('warning banner mentions override and static snapshot', async () => {
+    render(ShareEditModal, { props: defaultProps });
+
+    fireEvent.click(screen.getByRole('button', { name: /copy nights shares/i }));
+
+    await waitFor(() => {
+      const alert = screen.getByRole('alert');
+      expect(alert.textContent).toMatch(/overwrite/i);
+      expect(alert.textContent).toMatch(/static snapshot/i);
+    });
+  });
+});
+
+describe('ShareEditModal – Copy nights shares (AC4)', () => {
+  it('cancelling the warning dismisses it without changing input values', async () => {
+    render(ShareEditModal, { props: defaultProps });
+
+    fireEvent.click(screen.getByRole('button', { name: /copy nights shares/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toBeInTheDocument();
+    });
+
+    const alert = screen.getByRole('alert');
+    fireEvent.click(within(alert).getByRole('button', { name: /^cancel$/i }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    });
+
+    // Values unchanged: Alice still 5
+    const aliceInput = screen.getByRole('spinbutton', { name: /alice parts/i });
+    expect(aliceInput).toHaveValue(5);
+  });
+});
+
+describe('ShareEditModal – Copy nights shares (AC5 & AC6)', () => {
+  it('applying overwrites each participant parts with nights × share', async () => {
+    render(ShareEditModal, { props: defaultProps });
+
+    fireEvent.click(screen.getByRole('button', { name: /copy nights shares/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /^apply$/i })).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /^apply$/i }));
+
+    await waitFor(() => {
+      // Alice: 3 × 1 = 3
+      expect(screen.getByRole('spinbutton', { name: /alice parts/i })).toHaveValue(3);
+      // Bob: 2 × 2 = 4
+      expect(screen.getByRole('spinbutton', { name: /bob parts/i })).toHaveValue(4);
+      // Charlie: 4 × 1 = 4
+      expect(screen.getByRole('spinbutton', { name: /charlie parts/i })).toHaveValue(4);
+    });
+  });
+
+  it('applying closes the warning banner', async () => {
+    render(ShareEditModal, { props: defaultProps });
+
+    fireEvent.click(screen.getByRole('button', { name: /copy nights shares/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /^apply$/i })).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /^apply$/i }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    });
+  });
+
+  it('applying enables (checks) all participants', async () => {
+    const propsWithUnchecked = {
+      ...defaultProps,
+      initialData: {
+        shareParts: { p1: 5, p2: 0, p3: 5 },
+        shareChecked: { p1: true, p2: false, p3: true },
+        sharePreviousValues: { p1: 5, p2: 0, p3: 5 },
+      },
+    };
+
+    render(ShareEditModal, { props: propsWithUnchecked });
+
+    fireEvent.click(screen.getByRole('button', { name: /copy nights shares/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /^apply$/i })).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /^apply$/i }));
+
+    await waitFor(() => {
+      // Bob's input should now be enabled (checked)
+      const bobInput = screen.getByRole('spinbutton', { name: /bob parts/i });
+      expect(bobInput).not.toBeDisabled();
+    });
+  });
+});

--- a/src/doc/rules/frontend-rules.md
+++ b/src/doc/rules/frontend-rules.md
@@ -75,6 +75,10 @@
 
 - When a component function resets state and then awaits an async call (e.g., `loadChallenge` after a wrong answer), do not clear `errorMessage` at the top of the function. Clear it only in the success branch, after the await resolves. Clearing it synchronously at the top batches the reset with the other state changes before the first `await`, so the DOM never shows the error — breaking both UX (error flashes invisibly) and `waitFor` assertions in tests. Always pattern: set error → call `loadFn` → inside `loadFn`, clear error on success.
 
+## Scoping Queries When Multiple Elements Share the Same Label
+
+- When a component renders multiple buttons or elements with the same accessible name (e.g. two "Cancel" buttons — one in the modal footer, one inside a sub-banner), always scope `getByRole` queries using `within(container)` to avoid ambiguity errors. Use `within(screen.getByRole('alert'))`, `within(screen.getByRole('dialog'))`, or any distinct ARIA landmark to narrow the query to the relevant region.
+
 ## `getByText` Ambiguity from `<select>` Options
 
 - When entity names appear both as rendered text nodes AND as `<option>` values in a `<select>`, `getByText('Name')` will throw due to multiple matches. Use `getAllByText` when only testing presence, or use more specific queries (`getByRole('heading', { name: '...' })`, `getByRole('combobox', { name: '...' })`).

--- a/src/main/doc/implementation/2026-04-03-Feature-copy-nights-shares.md
+++ b/src/main/doc/implementation/2026-04-03-Feature-copy-nights-shares.md
@@ -1,0 +1,48 @@
+# Feature: Copy Nights Shares in Custom Expense
+
+## What, Why and Constraints
+
+**What:** Added a "Copy nights shares" button in the `ShareEditModal` (the edit shares view for FREE/custom expenses). When clicked, it shows an amber warning banner explaining that values will be overwritten and are a static snapshot. On confirmation, each participant's share parts are overwritten with `nights × share`, and all participants are enabled (checked).
+
+**Why:** Issue #87 — the BY_NIGHT split mode was the only way to use nights-weighted splits, but it's automatic and not customizable. Users wanted a shortcut to seed a FREE expense with nights-weighted values as a starting point, which they can then fine-tune manually.
+
+**Constraints:**
+- Frontend-only change. The backend already stores FREE expense parts as-is; no new API or calculation logic was needed.
+- The `Participant` type already exposes `nights` and `share` fields, so no data fetching was added.
+- Values are a static snapshot: future changes to a participant's nights or share are not reflected in the custom expense automatically (by design — this is a FREE expense).
+
+## How
+
+### Files modified
+
+**`fairnsquare-app/src/main/webui/src/lib/components/expense/ShareEditModal.svelte`**
+
+1. Added `Moon` and `AlertTriangle` to the lucide-svelte import.
+2. Added `showNightsWarning` reactive state (`$state(false)`).
+3. Added three functions:
+   - `copyNightsShares()` — sets `showNightsWarning = true`.
+   - `applyNightsShares()` — iterates participants, sets `localParts[id] = nights * share`, `localChecked[id] = true`, `localPreviousValues[id] = value`, then hides the warning.
+   - `cancelNightsWarning()` — sets `showNightsWarning = false`.
+4. Added the "Copy nights shares" button (outline, full-width, with Moon icon) below the description/total header row.
+5. Added an `{#if showNightsWarning}` amber banner (`role="alert"`) with an `AlertTriangle` icon, a warning message, and Apply/Cancel buttons scoped inside the banner.
+
+### Files created
+
+**`fairnsquare-app/src/main/webui/src/lib/components/expense/ShareEditModal.test.ts`**
+
+New test file for `ShareEditModal`. Previously no test file existed for this component.
+
+## Tests
+
+**File:** `src/lib/components/expense/ShareEditModal.test.ts`
+**Count:** 8 tests across 5 describe blocks
+
+| Describe (AC) | Tests |
+|---|---|
+| AC1 — Button rendered | "Copy nights shares" button is present in the modal |
+| AC2 — Warning shown | Clicking shows the alert banner; banner contains Apply and Cancel buttons |
+| AC3 — Warning content | Banner text matches /overwrite/ and /static snapshot/ |
+| AC4 — Cancel dismisses | Cancel hides banner, Alice's input value unchanged (still 5) |
+| AC5 & AC6 — Apply | Overwrites Alice→3, Bob→4, Charlie→4 (nights×share); banner disappears; Bob's input is enabled even if he was unchecked |
+
+All 8 tests pass.


### PR DESCRIPTION
## Summary

- Adds a **"Copy nights shares"** button in the `ShareEditModal` (edit shares view of custom expenses)
- Clicking the button shows an amber warning banner before applying, explaining that values will be overwritten and are a static snapshot (not synchronized with future nights/share edits)
- On confirmation, each participant's parts are overwritten with `nights × share` and all participants are enabled

## Test plan

- [x] 8 automated tests added in `ShareEditModal.test.ts` — all passing
- [x] Full test suite (455 tests) passes
- [ ] Manual: open a custom expense → Edit shares → click "Copy nights shares" → verify warning appears → Apply → verify parts updated correctly
- [ ] Manual: cancel the warning → verify no values changed

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)