### PR TITLE
refactor: remove captcha domain package from module exports (#97)

### DIFF
--- a/fairnsquare-app/src/main/java/org/asymetrik/web/fairnsquare/infrastructure/captcha/package-info.java
+++ b/fairnsquare-app/src/main/java/org/asymetrik/web/fairnsquare/infrastructure/captcha/package-info.java
@@ -2,8 +2,7 @@
  * CAPTCHA infrastructure — stateless human-verification challenges. Contains image generation, AES-GCM encrypted
  * challenge tokens, HMAC-SHA256 proof tokens, the REST API, and the JAX-RS request filter.
  */
-@Module(name = "captcha", exports = { "org.asymetrik.web.fairnsquare.infrastructure.captcha.api",
-        "org.asymetrik.web.fairnsquare.infrastructure.captcha.domain" })
+@Module(name = "captcha", exports = { "org.asymetrik.web.fairnsquare.infrastructure.captcha.api" })
 package org.asymetrik.web.fairnsquare.infrastructure.captcha;
 
 import org.asymetrik.modular.api.Module;

--- a/src/doc/rules/backend-rules.md
+++ b/src/doc/rules/backend-rules.md
@@ -44,6 +44,7 @@
 - Non-exported implementation details must be placed in a `<module>.internal` sub-package. Only classes that are intentionally part of the module's public API should remain in the root module package.
 - `ModularArchitectureTest` (plain JUnit, no `@QuarkusTest`) must scan `org.asymetrik.web.fairnsquare` and fail the build on any export violation or nested module violation.
 - When moving a class to an `internal` sub-package, Java package-private access is broken. Any fields or constants that test code or sibling classes need must be explicitly made `public`.
+- Domain packages (`*.domain`) must never be listed in a module's `@Module(exports = {...})`. Domain objects are internal implementation details. Only packages that form an explicit cross-module contract (e.g. annotations, shared interfaces) may be exported — typically the `api` package.
 
 ## Test-Only Code Must Not Live in Production Sources
 

--- a/src/main/doc/implementation/2026-04-03-Refactor-captcha-module-exports.md
+++ b/src/main/doc/implementation/2026-04-03-Refactor-captcha-module-exports.md
@@ -1,0 +1,43 @@
+# Refactor: Remove captcha domain from module exports
+
+## What, Why and Constraints
+
+**What:** Removed `org.asymetrik.web.fairnsquare.infrastructure.captcha.domain` from the `@Module(exports = {...})` declaration in the captcha module's `package-info.java`.
+
+**Why:** Issue #97 — the captcha module was exposing its internal domain objects (`CaptchaChallenge`, `CaptchaToken`, `CaptchaChallengeNotFoundError`, `CaptchaVerificationFailedError`) through the module's exported packages. These are implementation details that no other module needs to import directly. Exporting them violates the module boundary principle followed by all other modules (e.g. `split` exports nothing). Any module could have imported captcha domain classes, creating tight coupling to infrastructure internals.
+
+**Constraints:**
+- No other module imports anything from `captcha.domain` — the change is safe with zero consumer impact.
+- The `captcha.api` package (containing `CaptchaProtected`, the `@NameBinding` annotation used by `SplitResource`) remains exported, as required by the existing "Module Exports for Cross-Module Annotations" backend rule.
+
+## How
+
+### Files modified
+
+**`fairnsquare-app/src/main/java/org/asymetrik/web/fairnsquare/infrastructure/captcha/package-info.java`**
+
+Removed `"org.asymetrik.web.fairnsquare.infrastructure.captcha.domain"` from the `exports` array:
+
+```java
+// Before
+@Module(name = "captcha", exports = {
+    "org.asymetrik.web.fairnsquare.infrastructure.captcha.api",
+    "org.asymetrik.web.fairnsquare.infrastructure.captcha.domain"
+})
+
+// After
+@Module(name = "captcha", exports = {
+    "org.asymetrik.web.fairnsquare.infrastructure.captcha.api"
+})
+```
+
+**`src/doc/rules/backend-rules.md`**
+
+Added a new rule under "Module Boundaries":
+> Domain packages (`*.domain`) must never be listed in a module's `@Module(exports = {...})`. Domain objects are internal implementation details. Only packages that form an explicit cross-module contract (e.g. annotations, shared interfaces) may be exported — typically the `api` package.
+
+## Tests
+
+- `ModularArchitectureTest` — 1 test, passes. This test scans all module boundaries and fails the build on any export violation or illegal cross-module import.
+- Full backend test suite — BUILD SUCCESS, all tests pass.
+- No new tests added: this is a configuration-only change with no behavioural impact. The architecture test already enforces module boundary correctness.


### PR DESCRIPTION
## Summary

- Removes `org.asymetrik.web.fairnsquare.infrastructure.captcha.domain` from the captcha module's `@Module(exports = {...})`
- Domain objects (`CaptchaChallenge`, `CaptchaToken`, error classes) are internal implementation details — no other module imports them
- Aligns the captcha module with the boundary pattern used by all other modules (`split` exports nothing from its domain)
- Adds a backend rule: domain packages must never be exported from a module

## Test plan

- [x] `ModularArchitectureTest` passes (1 test)
- [x] Full backend test suite passes (BUILD SUCCESS)

Closes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)