### PR TITLE
feat: rework welcome page and expense modal (#94)

### DIFF
--- a/fairnsquare-app/src/main/webui/src/lib/components/expense/AddExpenseModal.test.ts
+++ b/fairnsquare-app/src/main/webui/src/lib/components/expense/AddExpenseModal.test.ts
@@ -103,12 +103,12 @@ describe('ExpenseEditModal', () => {
       expect(screen.getByText('Bob')).toBeInTheDocument();
     });
 
-    it('has auto-focus on amount field', async () => {
+    it('has auto-focus on description field', async () => {
       render(ExpenseEditModal, { props: defaultProps });
 
       await waitFor(() => {
-        const amountInput = screen.getByLabelText(/amount/i);
-        expect(document.activeElement).toBe(amountInput);
+        const descriptionInput = screen.getByLabelText(/description/i);
+        expect(document.activeElement).toBe(descriptionInput);
       });
     });
 

--- a/fairnsquare-app/src/main/webui/src/lib/components/expense/ExpenseEditModal.svelte
+++ b/fairnsquare-app/src/main/webui/src/lib/components/expense/ExpenseEditModal.svelte
@@ -159,7 +159,7 @@
       untrack(() => resetForm());
       setTimeout(() => {
         if (typeof document !== 'undefined') {
-          document.getElementById('expense-amount-modal')?.focus();
+          document.getElementById('expense-description-modal')?.focus();
         }
       }, 50);
     }
@@ -491,6 +491,24 @@
 
       <!-- Form -->
       <form onsubmit={(e) => { e.preventDefault(); handleSubmit(); }} class="p-4 space-y-4 overflow-y-auto flex-1">
+        <!-- Description Field -->
+        <div class="space-y-2">
+          <Label for="expense-description-modal">Description</Label>
+          <Input
+            id="expense-description-modal"
+            type="text"
+            placeholder="e.g., Groceries"
+            bind:value={description}
+            onblur={handleDescriptionBlur}
+            class="min-h-[44px]"
+            aria-invalid={descriptionTouched && !!validationErrors.description}
+            disabled={isLoading || isDeleting}
+          />
+          {#if descriptionTouched && validationErrors.description}
+            <p class="text-sm text-destructive">{validationErrors.description}</p>
+          {/if}
+        </div>
+
         <!-- Amount Field -->
         <div class="space-y-2">
           <Label for="expense-amount-modal">Amount (€)</Label>
@@ -508,24 +526,6 @@
           />
           {#if amountTouched && validationErrors.amount}
             <p class="text-sm text-destructive">{validationErrors.amount}</p>
-          {/if}
-        </div>
-
-        <!-- Description Field -->
-        <div class="space-y-2">
-          <Label for="expense-description-modal">Description</Label>
-          <Input
-            id="expense-description-modal"
-            type="text"
-            placeholder="e.g., Groceries"
-            bind:value={description}
-            onblur={handleDescriptionBlur}
-            class="min-h-[44px]"
-            aria-invalid={descriptionTouched && !!validationErrors.description}
-            disabled={isLoading || isDeleting}
-          />
-          {#if descriptionTouched && validationErrors.description}
-            <p class="text-sm text-destructive">{validationErrors.description}</p>
           {/if}
         </div>
 

--- a/fairnsquare-app/src/main/webui/src/lib/stores/lastSplitStore.test.ts
+++ b/fairnsquare-app/src/main/webui/src/lib/stores/lastSplitStore.test.ts
@@ -1,45 +1,84 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { saveLastSplit, loadLastSplit, clearLastSplit } from './lastSplitStore';
+import { saveLastSplit, loadLastSplits, removeLastSplit } from './lastSplitStore';
 
 describe('lastSplitStore', () => {
   beforeEach(() => {
     localStorage.clear();
   });
 
-  describe('loadLastSplit', () => {
-    it('returns null when nothing is stored', () => {
-      expect(loadLastSplit()).toBeNull();
+  describe('loadLastSplits', () => {
+    it('returns empty array when nothing is stored', () => {
+      expect(loadLastSplits()).toEqual([]);
     });
 
-    it('returns null when stored value is corrupt JSON', () => {
-      localStorage.setItem('fairnsquare_lastSplit', 'not-json');
-      expect(loadLastSplit()).toBeNull();
-    });
-  });
-
-  describe('saveLastSplit / loadLastSplit', () => {
-    it('saves and reloads a split', () => {
-      saveLastSplit({ id: 'abc123', name: 'Weekend Trip' });
-      expect(loadLastSplit()).toEqual({ id: 'abc123', name: 'Weekend Trip' });
+    it('returns empty array when stored value is corrupt JSON', () => {
+      localStorage.setItem('fairnsquare_lastSplits', 'not-json');
+      expect(loadLastSplits()).toEqual([]);
     });
 
-    it('overwrites a previously saved split', () => {
-      saveLastSplit({ id: 'old', name: 'Old Split' });
-      saveLastSplit({ id: 'new', name: 'New Split' });
-      expect(loadLastSplit()).toEqual({ id: 'new', name: 'New Split' });
+    it('returns empty array when stored value is not an array', () => {
+      localStorage.setItem('fairnsquare_lastSplits', JSON.stringify({ id: 'x', name: 'y' }));
+      expect(loadLastSplits()).toEqual([]);
     });
   });
 
-  describe('clearLastSplit', () => {
-    it('removes the stored split', () => {
-      saveLastSplit({ id: 'abc123', name: 'Weekend Trip' });
-      clearLastSplit();
-      expect(loadLastSplit()).toBeNull();
+  describe('saveLastSplit', () => {
+    it('saves a split and returns it as the first entry', () => {
+      saveLastSplit({ id: 'abc', name: 'Weekend Trip' });
+      expect(loadLastSplits()).toEqual([{ id: 'abc', name: 'Weekend Trip' }]);
     });
 
-    it('does nothing when nothing is stored', () => {
-      expect(() => clearLastSplit()).not.toThrow();
-      expect(loadLastSplit()).toBeNull();
+    it('prepends new split to the front of the list', () => {
+      saveLastSplit({ id: 'first', name: 'First' });
+      saveLastSplit({ id: 'second', name: 'Second' });
+      expect(loadLastSplits()[0]).toEqual({ id: 'second', name: 'Second' });
+      expect(loadLastSplits()[1]).toEqual({ id: 'first', name: 'First' });
+    });
+
+    it('deduplicates by id — moves existing split to front', () => {
+      saveLastSplit({ id: 'a', name: 'A' });
+      saveLastSplit({ id: 'b', name: 'B' });
+      saveLastSplit({ id: 'a', name: 'A updated' });
+      const splits = loadLastSplits();
+      expect(splits).toHaveLength(2);
+      expect(splits[0]).toEqual({ id: 'a', name: 'A updated' });
+      expect(splits[1]).toEqual({ id: 'b', name: 'B' });
+    });
+
+    it('caps the list at 10 entries', () => {
+      for (let i = 0; i < 12; i++) {
+        saveLastSplit({ id: `split-${i}`, name: `Split ${i}` });
+      }
+      expect(loadLastSplits()).toHaveLength(10);
+    });
+
+    it('keeps the most recent 10 when cap is exceeded', () => {
+      for (let i = 0; i < 12; i++) {
+        saveLastSplit({ id: `split-${i}`, name: `Split ${i}` });
+      }
+      const splits = loadLastSplits();
+      expect(splits[0].id).toBe('split-11');
+      expect(splits[9].id).toBe('split-2');
+    });
+  });
+
+  describe('removeLastSplit', () => {
+    it('removes the split with the given id', () => {
+      saveLastSplit({ id: 'a', name: 'A' });
+      saveLastSplit({ id: 'b', name: 'B' });
+      removeLastSplit('a');
+      expect(loadLastSplits()).toEqual([{ id: 'b', name: 'B' }]);
+    });
+
+    it('does nothing when the id is not found', () => {
+      saveLastSplit({ id: 'a', name: 'A' });
+      removeLastSplit('unknown');
+      expect(loadLastSplits()).toHaveLength(1);
+    });
+
+    it('does nothing when storage is empty', () => {
+      expect(() => removeLastSplit('x')).not.toThrow();
+      expect(loadLastSplits()).toEqual([]);
     });
   });
 });

--- a/fairnsquare-app/src/main/webui/src/lib/stores/lastSplitStore.ts
+++ b/fairnsquare-app/src/main/webui/src/lib/stores/lastSplitStore.ts
@@ -1,4 +1,5 @@
-const LAST_SPLIT_KEY = 'fairnsquare_lastSplit';
+const LAST_SPLITS_KEY = 'fairnsquare_lastSplits';
+const MAX_SPLITS = 10;
 
 export interface LastSplit {
   id: string;
@@ -6,19 +7,23 @@ export interface LastSplit {
 }
 
 export function saveLastSplit(split: LastSplit): void {
-  localStorage.setItem(LAST_SPLIT_KEY, JSON.stringify(split));
+  const current = loadLastSplits().filter((s) => s.id !== split.id);
+  const updated = [split, ...current].slice(0, MAX_SPLITS);
+  localStorage.setItem(LAST_SPLITS_KEY, JSON.stringify(updated));
 }
 
-export function loadLastSplit(): LastSplit | null {
-  const stored = localStorage.getItem(LAST_SPLIT_KEY);
-  if (!stored) return null;
+export function loadLastSplits(): LastSplit[] {
+  const stored = localStorage.getItem(LAST_SPLITS_KEY);
+  if (!stored) return [];
   try {
-    return JSON.parse(stored) as LastSplit;
+    const parsed = JSON.parse(stored);
+    return Array.isArray(parsed) ? parsed : [];
   } catch {
-    return null;
+    return [];
   }
 }
 
-export function clearLastSplit(): void {
-  localStorage.removeItem(LAST_SPLIT_KEY);
+export function removeLastSplit(id: string): void {
+  const updated = loadLastSplits().filter((s) => s.id !== id);
+  localStorage.setItem(LAST_SPLITS_KEY, JSON.stringify(updated));
 }

--- a/fairnsquare-app/src/main/webui/src/routes/Home.svelte
+++ b/fairnsquare-app/src/main/webui/src/routes/Home.svelte
@@ -1,16 +1,15 @@
 <script lang="ts">
-  // Home page - Create Split with First Participant
-  // Story FNS-002-1: Create Split Flow & Direct Dashboard Redirect
+  // Home page - Create Split
+  // Issue #94: Rework welcome page — list of recent splits, no first-participant form
   import { Button } from '$lib/components/ui/button';
   import { Input } from '$lib/components/ui/input';
   import * as Card from '$lib/components/ui/card';
   import { Label } from '$lib/components/ui/label';
-  import { createSplit, addParticipant, getSplit } from '$lib/api/splits';
+  import { createSplit, getSplit } from '$lib/api/splits';
   import { addToast } from '$lib/stores/toastStore.svelte';
   import type { ApiError } from '$lib/api/client';
   import { navigate } from '$lib/router';
-  import { loadLastSplit, clearLastSplit } from '$lib/stores/lastSplitStore';
-  import { saveNightsDefault } from '$lib/stores/nightsDefaultStore';
+  import { saveLastSplit, loadLastSplits, removeLastSplit } from '$lib/stores/lastSplitStore';
   import { hasValidToken, loadToken, clearToken, CAPTCHA_TOKEN_HEADER } from '$lib/stores/captchaStore';
   import CaptchaModal from '$lib/components/ui/captcha/CaptchaModal.svelte';
 
@@ -22,43 +21,40 @@
     doCreateSplit();
   }
 
-  // Resume state
-  interface ResumeCandidate { id: string; name: string }
-  let resumeSplit = $state<ResumeCandidate | null>(null);
+  // Recent splits state
+  interface RecentSplit { id: string; name: string }
+  let recentSplits = $state<RecentSplit[]>([]);
 
   $effect(() => {
-    const stored = loadLastSplit();
-    if (!stored) return;
-    getSplit(stored.id)
-      .then((split) => { resumeSplit = { id: split.id, name: split.name }; })
-      .catch(() => { clearLastSplit(); });
+    const stored = loadLastSplits();
+    if (stored.length === 0) return;
+    Promise.allSettled(stored.map((s) => getSplit(s.id))).then((results) => {
+      const verified: RecentSplit[] = [];
+      results.forEach((result, i) => {
+        if (result.status === 'fulfilled') {
+          verified.push({ id: result.value.id, name: result.value.name });
+        } else {
+          removeLastSplit(stored[i].id);
+        }
+      });
+      recentSplits = verified;
+    });
   });
 
-  function handleResume() {
-    if (resumeSplit) {
-      navigate('/splits/:splitId', { params: { splitId: resumeSplit.id } });
-    }
+  function handleResume(id: string) {
+    navigate('/splits/:splitId', { params: { splitId: id } });
   }
 
-  function handleDismiss() {
-    clearLastSplit();
-    resumeSplit = null;
+  function handleDismiss(id: string) {
+    removeLastSplit(id);
+    recentSplits = recentSplits.filter((s) => s.id !== id);
   }
 
   // Form state
   let splitName = $state('');
-  let participantName = $state('');
-  let nights = $state(1);
-  let share = $state(1);
   let isLoading = $state(false);
-
-  // Track whether fields have been touched for validation display
   let splitNameTouched = $state(false);
-  let participantNameTouched = $state(false);
-  let nightsTouched = $state(false);
-  let shareTouched = $state(false);
 
-  // Derived validation errors (only shown after field is touched)
   let splitNameError = $derived.by(() => {
     if (!splitNameTouched) return null;
     if (!splitName.trim()) return 'Split name is required';
@@ -66,53 +62,17 @@
     return null;
   });
 
-  let participantNameError = $derived.by(() => {
-    if (!participantNameTouched) return null;
-    if (!participantName.trim()) return 'Participant name is required';
-    if (participantName.length > 50) return 'Participant name cannot exceed 50 characters';
-    return null;
-  });
-
-  let nightsError = $derived.by(() => {
-    if (!nightsTouched) return null;
-    if (nights < 1) return 'Nights must be at least 1';
-    if (nights > 365) return 'Nights cannot exceed 365';
-    return null;
-  });
-
-  let shareError = $derived.by(() => {
-    if (!shareTouched) return null;
-    if (share < 0.5) return 'Share must be at least 0.5';
-    if (share > 50) return 'Share cannot exceed 50';
-    return null;
-  });
-
-  // Derived: form validity (independent of touched state)
   let isValid = $derived(
-    splitName.trim().length > 0 &&
-    splitName.length <= 100 &&
-    participantName.trim().length > 0 &&
-    participantName.length <= 50 &&
-    nights >= 1 &&
-    nights <= 365 &&
-    share >= 0.5 &&
-    share <= 50
+    splitName.trim().length > 0 && splitName.length <= 100
   );
 
   function handleCreateSplit() {
-    // Touch all fields to show errors
     splitNameTouched = true;
-    participantNameTouched = true;
-    nightsTouched = true;
-    shareTouched = true;
-
     if (!isValid) return;
-
     if (!hasValidToken()) {
       showCaptcha = true;
       return;
     }
-
     doCreateSplit();
   }
 
@@ -124,21 +84,7 @@
         showCaptcha = true;
         return;
       }
-
-      // Step 1: Create the split (with CAPTCHA token header)
       const split = await createSplit({ name: splitName.trim() }, { [CAPTCHA_TOKEN_HEADER]: token });
-
-      // Step 2: Add the first participant
-      await addParticipant(split.id, {
-        name: participantName.trim(),
-        nights,
-        share,
-      });
-
-      // Step 3: Persist the nights value so the next participant form defaults to it
-      saveNightsDefault(nights);
-
-      // Step 4: Go to participants page with form pre-opened to add next participant
       navigate('/splits/:splitId/participants', { params: { splitId: split.id }, search: { addParticipant: 'true' } });
     } catch (err) {
       const apiError = err as ApiError;
@@ -166,31 +112,6 @@
     <p class="text-muted-foreground mt-2">Split expenses fairly with friends</p>
   </header>
 
-  <!-- Resume Last Split -->
-  {#if resumeSplit}
-    <div class="w-full max-w-[520px]">
-      <Card.Root class="border-teal-300 bg-teal-50">
-        <Card.Header class="pb-2">
-          <Card.Title class="text-base">Resume your split</Card.Title>
-        </Card.Header>
-        <Card.Content class="space-y-3">
-          <p class="text-sm text-muted-foreground">You were working on <span class="font-medium text-foreground">{resumeSplit.name}</span>.</p>
-          <div class="flex items-center gap-3">
-            <Button onclick={handleResume} class="min-h-[44px]">
-              Resume
-            </Button>
-            <button
-              onclick={handleDismiss}
-              class="text-sm text-muted-foreground underline underline-offset-2 hover:text-foreground"
-            >
-              Dismiss
-            </button>
-          </div>
-        </Card.Content>
-      </Card.Root>
-    </div>
-  {/if}
-
   <!-- Create Split Form -->
   <div class="w-full max-w-[520px]">
     <Card.Root>
@@ -199,7 +120,6 @@
       </Card.Header>
       <Card.Content>
         <form onsubmit={(e) => { e.preventDefault(); handleCreateSplit(); }} class="space-y-4">
-          <!-- Split Name -->
           <div class="space-y-2">
             <Label for="splitName">Split Name</Label>
             <Input
@@ -221,80 +141,6 @@
             {/if}
           </div>
 
-          <!-- First Participant Section -->
-          <div class="rounded-lg border border-teal-300 bg-teal-50 p-4 space-y-3">
-            <p class="text-sm font-medium text-teal-700">First Participant</p>
-
-            <div class="space-y-2">
-              <Label for="participantName">Name</Label>
-              <Input
-                type="text"
-                id="participantName"
-                bind:value={participantName}
-                onblur={() => { participantNameTouched = true; }}
-                oninput={() => { participantNameTouched = true; }}
-                placeholder="Your name"
-                disabled={isLoading}
-                class="min-h-[44px]"
-                aria-invalid={participantNameError ? 'true' : undefined}
-                aria-describedby={participantNameError ? 'participantName-error' : undefined}
-              />
-              {#if participantNameError}
-                <p id="participantName-error" class="text-sm text-destructive">
-                  {participantNameError}
-                </p>
-              {/if}
-            </div>
-
-            <div class="flex gap-3">
-              <div class="space-y-2 flex-1">
-                <Label for="nights">Nights</Label>
-                <Input
-                  type="number"
-                  id="nights"
-                  bind:value={nights}
-                  onblur={() => { nightsTouched = true; }}
-                  oninput={() => { nightsTouched = true; }}
-                  step={1}
-                  min={1}
-                  max={365}
-                  disabled={isLoading}
-                  class="min-h-[44px]"
-                  aria-invalid={nightsError ? 'true' : undefined}
-                  aria-describedby={nightsError ? 'nights-error' : undefined}
-                />
-                {#if nightsError}
-                  <p id="nights-error" class="text-sm text-destructive">
-                    {nightsError}
-                  </p>
-                {/if}
-              </div>
-
-              <div class="space-y-2 flex-1">
-                <Label for="share">Share</Label>
-                <Input
-                  type="number"
-                  id="share"
-                  bind:value={share}
-                  onblur={() => { shareTouched = true; }}
-                  oninput={() => { shareTouched = true; }}
-                  step={0.5}
-                  min={0.5}
-                  max={50}
-                  disabled={isLoading}
-                  class="min-h-[44px]"
-                  aria-invalid={shareError ? 'true' : undefined}
-                  aria-describedby={shareError ? 'share-error' : undefined}
-                />
-                {#if shareError}
-                  <p id="share-error" class="text-sm text-destructive">
-                    {shareError}
-                  </p>
-                {/if}
-              </div>
-            </div>
-          </div>
-
           <Button
             type="submit"
             disabled={isLoading}
@@ -314,6 +160,33 @@
       </Card.Content>
     </Card.Root>
   </div>
+
+  <!-- Recent Splits -->
+  {#if recentSplits.length > 0}
+    <div class="w-full max-w-[520px]">
+      <Card.Root class="border-teal-300 bg-teal-50">
+        <Card.Header class="pb-2">
+          <Card.Title class="text-base">Recent splits</Card.Title>
+        </Card.Header>
+        <Card.Content class="space-y-2">
+          {#each recentSplits as split (split.id)}
+            <div class="flex items-center gap-3 min-h-[44px]">
+              <span class="flex-1 min-w-0 truncate text-sm font-medium text-foreground">{split.name}</span>
+              <Button size="sm" onclick={() => handleResume(split.id)} class="shrink-0 min-h-[36px]">
+                Resume
+              </Button>
+              <button
+                onclick={() => handleDismiss(split.id)}
+                class="shrink-0 text-sm text-muted-foreground underline underline-offset-2 hover:text-foreground"
+              >
+                Dismiss
+              </button>
+            </div>
+          {/each}
+        </Card.Content>
+      </Card.Root>
+    </div>
+  {/if}
 
   <!-- Info Section -->
   <section class="text-center text-muted-foreground text-sm max-w-[520px]">

--- a/fairnsquare-app/src/main/webui/src/routes/Home.test.ts
+++ b/fairnsquare-app/src/main/webui/src/routes/Home.test.ts
@@ -1,3 +1,16 @@
+/**
+ * Home page tests
+ * Issue #94: Rework welcome page
+ *
+ * AC1: Only split name field is shown (no participant form)
+ * AC2: Split name validation
+ * AC3: Create split calls only createSplit then navigates to participants page
+ * AC4: Recent splits list — verified splits shown, stale ones removed
+ * AC5: Individual dismiss per split
+ * AC6: Error handling
+ * AC7: CAPTCHA integration
+ */
+
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/svelte';
 import Home from './Home.svelte';
@@ -13,7 +26,6 @@ vi.mock('$lib/router', () => ({
 // Mock the API
 vi.mock('$lib/api/splits', () => ({
   createSplit: vi.fn(),
-  addParticipant: vi.fn(),
   getSplit: vi.fn(),
 }));
 
@@ -24,15 +36,9 @@ vi.mock('$lib/stores/toastStore.svelte', () => ({
 
 // Mock the lastSplitStore
 vi.mock('$lib/stores/lastSplitStore', () => ({
-  loadLastSplit: vi.fn(),
-  clearLastSplit: vi.fn(),
+  loadLastSplits: vi.fn(),
+  removeLastSplit: vi.fn(),
   saveLastSplit: vi.fn(),
-}));
-
-// Mock the nights default store
-vi.mock('$lib/stores/nightsDefaultStore', () => ({
-  saveNightsDefault: vi.fn(),
-  loadNightsDefault: vi.fn(() => 1),
 }));
 
 // Mock the captcha store — default: token is valid so modal is suppressed
@@ -50,575 +56,297 @@ vi.mock('$lib/api/captcha', () => ({
   verifyChallenge: vi.fn(),
 }));
 
-import { createSplit, addParticipant, getSplit } from '$lib/api/splits';
+import { createSplit, getSplit } from '$lib/api/splits';
 import { navigate } from '$lib/router';
 import { addToast } from '$lib/stores/toastStore.svelte';
-import { loadLastSplit, clearLastSplit } from '$lib/stores/lastSplitStore';
-import { saveNightsDefault } from '$lib/stores/nightsDefaultStore';
+import { loadLastSplits, removeLastSplit } from '$lib/stores/lastSplitStore';
 import { hasValidToken, loadToken, clearToken } from '$lib/stores/captchaStore';
+
+const mockSplit = {
+  id: 'abc123',
+  name: 'Weekend Trip',
+  createdAt: '2026-02-04T12:00:00Z',
+  participants: [],
+  expenses: [],
+  settlement: null,
+};
 
 describe('Home', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.mocked(loadLastSplit).mockReturnValue(null);
+    vi.mocked(loadLastSplits).mockReturnValue([]);
   });
 
-  // --- Task 1: Form renders all fields (AC: 1) ---
+  // --- AC1: Form renders only split name field ---
 
-  it('renders all form fields: split name, participant name, nights, share', () => {
-    render(Home);
+  describe('Form rendering (AC1)', () => {
+    it('renders the split name field and Create Split button', () => {
+      render(Home);
 
-    expect(screen.getByText('FairNSquare')).toBeInTheDocument();
-    expect(screen.getByText('Create a New Split')).toBeInTheDocument();
-    expect(screen.getByLabelText('Split Name')).toBeInTheDocument();
-    expect(screen.getByText('First Participant')).toBeInTheDocument();
-    expect(screen.getByLabelText('Name')).toBeInTheDocument();
-    expect(screen.getByLabelText('Nights')).toBeInTheDocument();
-    expect(screen.getByLabelText('Share')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Create Split' })).toBeInTheDocument();
-  });
-
-  it('defaults nights to 1', () => {
-    render(Home);
-
-    const nightsInput = screen.getByLabelText('Nights') as HTMLInputElement;
-    expect(nightsInput.value).toBe('1');
-  });
-
-  it('defaults share to 1', () => {
-    render(Home);
-
-    const shareInput = screen.getByLabelText('Share') as HTMLInputElement;
-    expect(shareInput.value).toBe('1');
-  });
-
-  // --- Task 2: Validation (AC: 2, 3, 4, 5) ---
-
-  it('shows validation errors when submitting with empty fields', async () => {
-    render(Home);
-
-    const submitButton = screen.getByRole('button', { name: 'Create Split' });
-    expect(submitButton).not.toBeDisabled();
-
-    await fireEvent.click(submitButton);
-
-    expect(screen.getByText('Split name is required')).toBeInTheDocument();
-    expect(screen.getByText('Participant name is required')).toBeInTheDocument();
-  });
-
-  it('enables submit button when all fields are valid', async () => {
-    render(Home);
-
-    await fireEvent.input(screen.getByLabelText('Split Name'), {
-      target: { value: 'Weekend Trip' },
-    });
-    await fireEvent.input(screen.getByLabelText('Name'), {
-      target: { value: 'Alice' },
+      expect(screen.getByText('FairNSquare')).toBeInTheDocument();
+      expect(screen.getByText('Create a New Split')).toBeInTheDocument();
+      expect(screen.getByLabelText('Split Name')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Create Split' })).toBeInTheDocument();
     });
 
-    const submitButton = screen.getByRole('button', { name: 'Create Split' });
-    expect(submitButton).not.toBeDisabled();
-  });
+    it('does not render participant form fields', () => {
+      render(Home);
 
-  it('shows validation error for split name exceeding 100 characters', async () => {
-    render(Home);
-
-    const longName = 'a'.repeat(101);
-    const input = screen.getByLabelText('Split Name');
-    await fireEvent.input(input, { target: { value: longName } });
-
-    expect(
-      screen.getByText('Split name cannot exceed 100 characters')
-    ).toBeInTheDocument();
-  });
-
-  it('shows validation error for participant name exceeding 50 characters', async () => {
-    render(Home);
-
-    const longName = 'a'.repeat(51);
-    const input = screen.getByLabelText('Name');
-    await fireEvent.input(input, { target: { value: longName } });
-
-    expect(
-      screen.getByText('Participant name cannot exceed 50 characters')
-    ).toBeInTheDocument();
-  });
-
-  it('shows validation error for nights less than 1', async () => {
-    render(Home);
-
-    const nightsInput = screen.getByLabelText('Nights');
-    await fireEvent.input(nightsInput, { target: { value: 0 } });
-
-    expect(screen.getByText('Nights must be at least 1')).toBeInTheDocument();
-  });
-
-  it('shows validation error for nights greater than 365', async () => {
-    render(Home);
-
-    const nightsInput = screen.getByLabelText('Nights');
-    await fireEvent.input(nightsInput, { target: { value: 366 } });
-
-    expect(screen.getByText('Nights cannot exceed 365')).toBeInTheDocument();
-  });
-
-  it('shows validation error for share less than 0.5', async () => {
-    render(Home);
-
-    const shareInput = screen.getByLabelText('Share');
-    await fireEvent.input(shareInput, { target: { value: 0 } });
-
-    expect(screen.getByText('Share must be at least 0.5')).toBeInTheDocument();
-  });
-
-  it('shows validation error for share greater than 50', async () => {
-    render(Home);
-
-    const shareInput = screen.getByLabelText('Share');
-    await fireEvent.input(shareInput, { target: { value: 51 } });
-
-    expect(screen.getByText('Share cannot exceed 50')).toBeInTheDocument();
-  });
-
-  // --- Task 3: Create flow & redirect (AC: 6) ---
-
-  it('creates split, adds participant, and navigates to split page', async () => {
-    const mockSplit = {
-      id: 'abc123',
-      name: 'Weekend Trip',
-      createdAt: '2026-02-04T12:00:00Z',
-      participants: [],
-      expenses: [],
-    };
-    const mockParticipant = {
-      id: 'p1',
-      name: 'Alice',
-      nights: 3,
-      share: 1,
-    };
-    vi.mocked(createSplit).mockResolvedValue(mockSplit);
-    vi.mocked(addParticipant).mockResolvedValue(mockParticipant);
-
-    render(Home);
-
-    await fireEvent.input(screen.getByLabelText('Split Name'), {
-      target: { value: 'Weekend Trip' },
+      expect(screen.queryByText('First Participant')).not.toBeInTheDocument();
+      expect(screen.queryByLabelText('Name')).not.toBeInTheDocument();
+      expect(screen.queryByLabelText('Nights')).not.toBeInTheDocument();
+      expect(screen.queryByLabelText('Share')).not.toBeInTheDocument();
     });
-    await fireEvent.input(screen.getByLabelText('Name'), {
-      target: { value: 'Alice' },
-    });
-    await fireEvent.input(screen.getByLabelText('Nights'), {
-      target: { value: 3 },
+  });
+
+  // --- AC2: Validation ---
+
+  describe('Validation (AC2)', () => {
+    it('shows split name required error when submitting empty form', async () => {
+      render(Home);
+
+      await fireEvent.click(screen.getByRole('button', { name: 'Create Split' }));
+
+      expect(screen.getByText('Split name is required')).toBeInTheDocument();
     });
 
-    const submitButton = screen.getByRole('button', { name: 'Create Split' });
-    await fireEvent.click(submitButton);
+    it('shows error when split name exceeds 100 characters', async () => {
+      render(Home);
 
-    await waitFor(() => {
-      expect(createSplit).toHaveBeenCalledWith(
-        { name: 'Weekend Trip' },
-        { 'X-Captcha-Token': 'mock-captcha-token' }
-      );
-      expect(addParticipant).toHaveBeenCalledWith('abc123', {
-        name: 'Alice',
-        nights: 3,
-        share: 1,
+      await fireEvent.input(screen.getByLabelText('Split Name'), {
+        target: { value: 'a'.repeat(101) },
       });
-      expect(navigate).toHaveBeenCalledWith('/splits/:splitId/participants', {
-        params: { splitId: 'abc123' },
-        search: { addParticipant: 'true' },
+
+      expect(screen.getByText('Split name cannot exceed 100 characters')).toBeInTheDocument();
+    });
+
+    it('does not call createSplit when form is invalid', async () => {
+      render(Home);
+
+      await fireEvent.click(screen.getByRole('button', { name: 'Create Split' }));
+
+      expect(createSplit).not.toHaveBeenCalled();
+    });
+  });
+
+  // --- AC3: Create flow ---
+
+  describe('Create flow (AC3)', () => {
+    it('calls createSplit with split name and navigates to participants page', async () => {
+      vi.mocked(createSplit).mockResolvedValue(mockSplit);
+
+      render(Home);
+
+      await fireEvent.input(screen.getByLabelText('Split Name'), {
+        target: { value: 'Weekend Trip' },
+      });
+      await fireEvent.click(screen.getByRole('button', { name: 'Create Split' }));
+
+      await waitFor(() => {
+        expect(createSplit).toHaveBeenCalledWith(
+          { name: 'Weekend Trip' },
+          { 'X-Captcha-Token': 'mock-captcha-token' }
+        );
+        expect(navigate).toHaveBeenCalledWith('/splits/:splitId/participants', {
+          params: { splitId: 'abc123' },
+          search: { addParticipant: 'true' },
+        });
       });
     });
-  });
 
-  it('saves nights default after creating split so next participant form defaults to it', async () => {
-    const mockSplit = {
-      id: 'abc123',
-      name: 'Weekend Trip',
-      createdAt: '2026-02-04T12:00:00Z',
-      participants: [],
-      expenses: [],
-    };
-    vi.mocked(createSplit).mockResolvedValue(mockSplit);
-    vi.mocked(addParticipant).mockResolvedValue({ id: 'p1', name: 'Alice', nights: 7, share: 1 });
+    it('does not call addParticipant during split creation', async () => {
+      vi.mocked(createSplit).mockResolvedValue(mockSplit);
 
-    render(Home);
+      render(Home);
 
-    await fireEvent.input(screen.getByLabelText('Split Name'), { target: { value: 'Weekend Trip' } });
-    await fireEvent.input(screen.getByLabelText('Name'), { target: { value: 'Alice' } });
-    await fireEvent.input(screen.getByLabelText('Nights'), { target: { value: 7 } });
+      await fireEvent.input(screen.getByLabelText('Split Name'), {
+        target: { value: 'Weekend Trip' },
+      });
+      await fireEvent.click(screen.getByRole('button', { name: 'Create Split' }));
 
-    await fireEvent.click(screen.getByRole('button', { name: 'Create Split' }));
+      await waitFor(() => expect(navigate).toHaveBeenCalled());
 
-    await waitFor(() => {
-      expect(saveNightsDefault).toHaveBeenCalledWith(7);
+      // addParticipant is not in the mock — createSplit is the only API call
+      expect(createSplit).toHaveBeenCalledTimes(1);
     });
   });
 
-  it('does not save nights default when API call fails', async () => {
-    vi.mocked(createSplit).mockRejectedValue({ detail: 'Server error' });
+  // --- AC4: Recent splits list ---
 
-    render(Home);
+  describe('Recent splits list (AC4)', () => {
+    it('does not show recent splits section when list is empty', async () => {
+      vi.mocked(loadLastSplits).mockReturnValue([]);
 
-    await fireEvent.input(screen.getByLabelText('Split Name'), { target: { value: 'Weekend Trip' } });
-    await fireEvent.input(screen.getByLabelText('Name'), { target: { value: 'Alice' } });
+      render(Home);
 
-    await fireEvent.click(screen.getByRole('button', { name: 'Create Split' }));
-
-    await waitFor(() => {
-      expect(addToast).toHaveBeenCalled();
+      await waitFor(() => {
+        expect(screen.queryByText('Recent splits')).not.toBeInTheDocument();
+      });
     });
 
-    expect(saveNightsDefault).not.toHaveBeenCalled();
+    it('shows verified splits from the store', async () => {
+      vi.mocked(loadLastSplits).mockReturnValue([
+        { id: 's1', name: 'Beach House' },
+        { id: 's2', name: 'Road Trip' },
+      ]);
+      vi.mocked(getSplit)
+        .mockResolvedValueOnce({ ...mockSplit, id: 's1', name: 'Beach House' })
+        .mockResolvedValueOnce({ ...mockSplit, id: 's2', name: 'Road Trip' });
+
+      render(Home);
+
+      await waitFor(() => {
+        expect(screen.getByText('Recent splits')).toBeInTheDocument();
+        expect(screen.getByText('Beach House')).toBeInTheDocument();
+        expect(screen.getByText('Road Trip')).toBeInTheDocument();
+      });
+    });
+
+    it('removes stale splits (not found on server) from storage and list', async () => {
+      vi.mocked(loadLastSplits).mockReturnValue([
+        { id: 'gone', name: 'Old Split' },
+        { id: 's2', name: 'Active Split' },
+      ]);
+      vi.mocked(getSplit)
+        .mockRejectedValueOnce({ status: 404 })
+        .mockResolvedValueOnce({ ...mockSplit, id: 's2', name: 'Active Split' });
+
+      render(Home);
+
+      await waitFor(() => {
+        expect(removeLastSplit).toHaveBeenCalledWith('gone');
+        expect(screen.queryByText('Old Split')).not.toBeInTheDocument();
+        expect(screen.getByText('Active Split')).toBeInTheDocument();
+      });
+    });
+
+    it('navigates to split when Resume is clicked', async () => {
+      vi.mocked(loadLastSplits).mockReturnValue([{ id: 's1', name: 'Beach House' }]);
+      vi.mocked(getSplit).mockResolvedValue({ ...mockSplit, id: 's1', name: 'Beach House' });
+
+      render(Home);
+
+      await waitFor(() => expect(screen.getByText('Beach House')).toBeInTheDocument());
+
+      await fireEvent.click(screen.getByRole('button', { name: 'Resume' }));
+
+      expect(navigate).toHaveBeenCalledWith('/splits/:splitId', { params: { splitId: 's1' } });
+    });
   });
 
-  it('sends share in API call', async () => {
-    const mockSplit = {
-      id: 'abc123',
-      name: 'Weekend Trip',
-      createdAt: '2026-02-04T12:00:00Z',
-      participants: [],
-      expenses: [],
-    };
-    vi.mocked(createSplit).mockResolvedValue(mockSplit);
-    vi.mocked(addParticipant).mockResolvedValue({
-      id: 'p1',
-      name: 'Alice',
-      nights: 2,
-      share: 3,
-    });
+  // --- AC5: Individual dismiss ---
 
-    render(Home);
+  describe('Individual dismiss (AC5)', () => {
+    it('removes a dismissed split from the list and calls removeLastSplit', async () => {
+      vi.mocked(loadLastSplits).mockReturnValue([
+        { id: 's1', name: 'Beach House' },
+        { id: 's2', name: 'Road Trip' },
+      ]);
+      vi.mocked(getSplit)
+        .mockResolvedValueOnce({ ...mockSplit, id: 's1', name: 'Beach House' })
+        .mockResolvedValueOnce({ ...mockSplit, id: 's2', name: 'Road Trip' });
 
-    await fireEvent.input(screen.getByLabelText('Split Name'), {
-      target: { value: 'Weekend Trip' },
-    });
-    await fireEvent.input(screen.getByLabelText('Name'), {
-      target: { value: 'Alice' },
-    });
-    await fireEvent.input(screen.getByLabelText('Nights'), {
-      target: { value: 2 },
-    });
-    await fireEvent.input(screen.getByLabelText('Share'), {
-      target: { value: 3 },
-    });
+      render(Home);
 
-    await fireEvent.click(screen.getByRole('button', { name: 'Create Split' }));
+      await waitFor(() => expect(screen.getAllByText('Dismiss')).toHaveLength(2));
 
-    await waitFor(() => {
-      expect(addParticipant).toHaveBeenCalledWith('abc123', {
-        name: 'Alice',
-        nights: 2,
-        share: 3,
+      await fireEvent.click(screen.getAllByText('Dismiss')[0]);
+
+      await waitFor(() => {
+        expect(removeLastSplit).toHaveBeenCalledWith('s1');
+        expect(screen.queryByText('Beach House')).not.toBeInTheDocument();
+        expect(screen.getByText('Road Trip')).toBeInTheDocument();
       });
     });
   });
 
-  // --- Task 4: No intermediate share-link screen (AC: 6) ---
+  // --- AC6: Error handling ---
 
-  it('does not show share-link screen after creation', async () => {
-    const mockSplit = {
-      id: 'abc123',
-      name: 'Weekend Trip',
-      createdAt: '2026-02-04T12:00:00Z',
-      participants: [],
-      expenses: [],
-    };
-    vi.mocked(createSplit).mockResolvedValue(mockSplit);
-    vi.mocked(addParticipant).mockResolvedValue({
-      id: 'p1',
-      name: 'Alice',
-      nights: 1,
-      share: 1,
-    });
+  describe('Error handling (AC6)', () => {
+    it('shows toast on createSplit API error and preserves form data', async () => {
+      vi.mocked(createSplit).mockRejectedValue({ detail: 'Server error' });
 
-    render(Home);
+      render(Home);
 
-    await fireEvent.input(screen.getByLabelText('Split Name'), {
-      target: { value: 'Weekend Trip' },
-    });
-    await fireEvent.input(screen.getByLabelText('Name'), {
-      target: { value: 'Alice' },
-    });
-
-    await fireEvent.click(screen.getByRole('button', { name: 'Create Split' }));
-
-    await waitFor(() => {
-      expect(navigate).toHaveBeenCalled();
-    });
-
-    // These elements from the old share-link screen must NOT appear
-    expect(screen.queryByText('Split Created!')).not.toBeInTheDocument();
-    expect(screen.queryByText('Go to Split')).not.toBeInTheDocument();
-    expect(screen.queryByText('Create Another Split')).not.toBeInTheDocument();
-    expect(screen.queryByText('Copy Link')).not.toBeInTheDocument();
-  });
-
-  // --- Task 5: Error handling (AC: 7) ---
-
-  it('shows toast on createSplit API error and preserves form data', async () => {
-    vi.mocked(createSplit).mockRejectedValue({
-      type: 'error',
-      title: 'Error',
-      status: 500,
-      detail: 'Server error',
-    });
-
-    render(Home);
-
-    await fireEvent.input(screen.getByLabelText('Split Name'), {
-      target: { value: 'Weekend Trip' },
-    });
-    await fireEvent.input(screen.getByLabelText('Name'), {
-      target: { value: 'Alice' },
-    });
-
-    await fireEvent.click(screen.getByRole('button', { name: 'Create Split' }));
-
-    await waitFor(() => {
-      expect(addToast).toHaveBeenCalledWith({
-        type: 'error',
-        message: 'Server error',
+      await fireEvent.input(screen.getByLabelText('Split Name'), {
+        target: { value: 'Weekend Trip' },
       });
-    });
+      await fireEvent.click(screen.getByRole('button', { name: 'Create Split' }));
 
-    // Form data preserved
-    expect((screen.getByLabelText('Split Name') as HTMLInputElement).value).toBe(
-      'Weekend Trip'
-    );
-    expect((screen.getByLabelText('Name') as HTMLInputElement).value).toBe('Alice');
-    expect(navigate).not.toHaveBeenCalled();
-  });
-
-  it('shows toast on addParticipant API error and preserves form data', async () => {
-    const mockSplit = {
-      id: 'abc123',
-      name: 'Weekend Trip',
-      createdAt: '2026-02-04T12:00:00Z',
-      participants: [],
-      expenses: [],
-    };
-    vi.mocked(createSplit).mockResolvedValue(mockSplit);
-    vi.mocked(addParticipant).mockRejectedValue({
-      type: 'error',
-      title: 'Error',
-      status: 400,
-      detail: 'Invalid participant',
-    });
-
-    render(Home);
-
-    await fireEvent.input(screen.getByLabelText('Split Name'), {
-      target: { value: 'Weekend Trip' },
-    });
-    await fireEvent.input(screen.getByLabelText('Name'), {
-      target: { value: 'Alice' },
-    });
-
-    await fireEvent.click(screen.getByRole('button', { name: 'Create Split' }));
-
-    await waitFor(() => {
-      expect(addToast).toHaveBeenCalledWith({
-        type: 'error',
-        message: 'Invalid participant',
+      await waitFor(() => {
+        expect(addToast).toHaveBeenCalledWith({ type: 'error', message: 'Server error' });
       });
+
+      expect((screen.getByLabelText('Split Name') as HTMLInputElement).value).toBe('Weekend Trip');
+      expect(navigate).not.toHaveBeenCalled();
     });
 
-    expect(navigate).not.toHaveBeenCalled();
-  });
+    it('shows default error message when API error has no detail', async () => {
+      vi.mocked(createSplit).mockRejectedValue({});
 
-  it('shows default error message when API error has no detail', async () => {
-    vi.mocked(createSplit).mockRejectedValue({});
+      render(Home);
 
-    render(Home);
+      await fireEvent.input(screen.getByLabelText('Split Name'), {
+        target: { value: 'Weekend Trip' },
+      });
+      await fireEvent.click(screen.getByRole('button', { name: 'Create Split' }));
 
-    await fireEvent.input(screen.getByLabelText('Split Name'), {
-      target: { value: 'Weekend Trip' },
-    });
-    await fireEvent.input(screen.getByLabelText('Name'), {
-      target: { value: 'Alice' },
-    });
-
-    await fireEvent.click(screen.getByRole('button', { name: 'Create Split' }));
-
-    await waitFor(() => {
-      expect(addToast).toHaveBeenCalledWith({
-        type: 'error',
-        message: 'Failed to create split',
+      await waitFor(() => {
+        expect(addToast).toHaveBeenCalledWith({ type: 'error', message: 'Failed to create split' });
       });
     });
   });
 
-  // --- Resume last split ---
+  // --- AC7: CAPTCHA integration ---
 
-  it('does not show resume card when no split is stored', async () => {
-    vi.mocked(loadLastSplit).mockReturnValue(null);
+  describe('CAPTCHA integration (AC7)', () => {
+    it('shows captcha modal when no valid token and form is valid', async () => {
+      vi.mocked(hasValidToken).mockReturnValue(false);
 
-    render(Home);
+      render(Home);
 
-    await waitFor(() => {
-      expect(screen.queryByText('Resume your split')).not.toBeInTheDocument();
-    });
-  });
+      await fireEvent.input(screen.getByLabelText('Split Name'), { target: { value: 'Trip' } });
+      await fireEvent.click(screen.getByRole('button', { name: 'Create Split' }));
 
-  it('shows resume card with split name when stored split exists and is verified', async () => {
-    vi.mocked(loadLastSplit).mockReturnValue({ id: 'abc123', name: 'Weekend Trip' });
-    vi.mocked(getSplit).mockResolvedValue({
-      id: 'abc123',
-      name: 'Weekend Trip',
-      createdAt: '2026-01-01T00:00:00Z',
-      participants: [],
-      expenses: [],
-      settlement: null,
+      await waitFor(() => {
+        expect(screen.getByRole('dialog')).toBeInTheDocument();
+        expect(screen.getByText('Human Verification')).toBeInTheDocument();
+      });
+      expect(createSplit).not.toHaveBeenCalled();
     });
 
-    render(Home);
+    it('does not show captcha modal when valid token exists', async () => {
+      vi.mocked(hasValidToken).mockReturnValue(true);
+      vi.mocked(createSplit).mockResolvedValue(mockSplit);
 
-    await waitFor(() => {
-      expect(screen.getByText('Resume your split')).toBeInTheDocument();
-      expect(screen.getByText('Weekend Trip')).toBeInTheDocument();
-      expect(screen.getByRole('button', { name: 'Resume' })).toBeInTheDocument();
-      expect(screen.getByText('Dismiss')).toBeInTheDocument();
-    });
-  });
+      render(Home);
 
-  it('does not show resume card when stored split is not found on server', async () => {
-    vi.mocked(loadLastSplit).mockReturnValue({ id: 'gone', name: 'Old Split' });
-    vi.mocked(getSplit).mockRejectedValue({ status: 404, detail: 'Not found' });
+      await fireEvent.input(screen.getByLabelText('Split Name'), { target: { value: 'Trip' } });
+      await fireEvent.click(screen.getByRole('button', { name: 'Create Split' }));
 
-    render(Home);
-
-    await waitFor(() => {
-      expect(clearLastSplit).toHaveBeenCalled();
-      expect(screen.queryByText('Resume your split')).not.toBeInTheDocument();
-    });
-  });
-
-  it('navigates to split when Resume is clicked', async () => {
-    vi.mocked(loadLastSplit).mockReturnValue({ id: 'abc123', name: 'Weekend Trip' });
-    vi.mocked(getSplit).mockResolvedValue({
-      id: 'abc123',
-      name: 'Weekend Trip',
-      createdAt: '2026-01-01T00:00:00Z',
-      participants: [],
-      expenses: [],
-      settlement: null,
+      await waitFor(() => expect(createSplit).toHaveBeenCalled());
+      expect(screen.queryByText('Human Verification')).not.toBeInTheDocument();
     });
 
-    render(Home);
+    it('clears token and shows captcha modal when createSplit returns 401', async () => {
+      vi.mocked(createSplit).mockRejectedValue({ status: 401 });
 
-    await waitFor(() => {
-      expect(screen.getByRole('button', { name: 'Resume' })).toBeInTheDocument();
+      render(Home);
+
+      await fireEvent.input(screen.getByLabelText('Split Name'), { target: { value: 'Trip' } });
+      await fireEvent.click(screen.getByRole('button', { name: 'Create Split' }));
+
+      await waitFor(() => {
+        expect(clearToken).toHaveBeenCalled();
+        expect(screen.getByRole('dialog')).toBeInTheDocument();
+      });
+      expect(addToast).not.toHaveBeenCalled();
     });
 
-    await fireEvent.click(screen.getByRole('button', { name: 'Resume' }));
-
-    expect(navigate).toHaveBeenCalledWith('/splits/:splitId', { params: { splitId: 'abc123' } });
-  });
-
-  // --- CAPTCHA integration ---
-
-  it('shows captcha modal when Create Split is clicked and no valid token is stored', async () => {
-    vi.mocked(hasValidToken).mockReturnValue(false);
-
-    render(Home);
-
-    await fireEvent.input(screen.getByLabelText('Split Name'), { target: { value: 'Trip' } });
-    await fireEvent.input(screen.getByLabelText('Name'), { target: { value: 'Alice' } });
-    await fireEvent.click(screen.getByRole('button', { name: 'Create Split' }));
-
-    await waitFor(() => {
-      expect(screen.getByRole('dialog')).toBeInTheDocument();
-      expect(screen.getByText('Human Verification')).toBeInTheDocument();
-    });
-    expect(createSplit).not.toHaveBeenCalled();
-  });
-
-  it('does not show captcha modal when Create Split is clicked and a valid token is stored', async () => {
-    vi.mocked(hasValidToken).mockReturnValue(true);
-    vi.mocked(createSplit).mockResolvedValue({ id: 'abc', name: 'Trip', createdAt: '', participants: [], expenses: [] });
-    vi.mocked(addParticipant).mockResolvedValue({ id: 'p1', name: 'Alice', nights: 1, share: 1 });
-
-    render(Home);
-
-    await fireEvent.input(screen.getByLabelText('Split Name'), { target: { value: 'Trip' } });
-    await fireEvent.input(screen.getByLabelText('Name'), { target: { value: 'Alice' } });
-    await fireEvent.click(screen.getByRole('button', { name: 'Create Split' }));
-
-    await waitFor(() => {
-      expect(createSplit).toHaveBeenCalled();
-    });
-    expect(screen.queryByText('Human Verification')).not.toBeInTheDocument();
-  });
-
-  it('does not show captcha modal on page load even when no token is stored', () => {
-    vi.mocked(hasValidToken).mockReturnValue(false);
-
-    render(Home);
-
-    expect(screen.queryByText('Human Verification')).not.toBeInTheDocument();
-  });
-
-  it('auto-proceeds with split creation after captcha is solved', async () => {
-    vi.mocked(hasValidToken).mockReturnValueOnce(false).mockReturnValue(true);
-    const mockSplit = { id: 'abc', name: 'Trip', createdAt: '', participants: [], expenses: [] };
-    vi.mocked(createSplit).mockResolvedValue(mockSplit);
-    vi.mocked(addParticipant).mockResolvedValue({ id: 'p1', name: 'Alice', nights: 1, share: 1 });
-
-    render(Home);
-
-    await fireEvent.input(screen.getByLabelText('Split Name'), { target: { value: 'Trip' } });
-    await fireEvent.input(screen.getByLabelText('Name'), { target: { value: 'Alice' } });
-    await fireEvent.click(screen.getByRole('button', { name: 'Create Split' }));
-
-    // Modal should appear
-    await waitFor(() => expect(screen.getByText('Human Verification')).toBeInTheDocument());
-
-    // Simulate captcha solved — find and click the success path via the store mock
-    // The CaptchaModal is mocked via captcha API mocks; simulate onSuccess by directly
-    // triggering the internal state. We verify that once hasValidToken returns true,
-    // the creation call proceeds.
-    expect(createSplit).not.toHaveBeenCalled();
-  });
-
-  it('clears token and shows captcha modal when createSplit returns 401', async () => {
-    vi.mocked(createSplit).mockRejectedValue({ status: 401, detail: 'CAPTCHA required' });
-
-    render(Home);
-
-    await fireEvent.input(screen.getByLabelText('Split Name'), { target: { value: 'Trip' } });
-    await fireEvent.input(screen.getByLabelText('Name'), { target: { value: 'Alice' } });
-    await fireEvent.click(screen.getByRole('button', { name: 'Create Split' }));
-
-    await waitFor(() => {
-      expect(clearToken).toHaveBeenCalled();
-      expect(screen.getByRole('dialog')).toBeInTheDocument();
-    });
-    expect(addToast).not.toHaveBeenCalled();
-  });
-
-  it('hides resume card and clears storage when Dismiss is clicked', async () => {
-    vi.mocked(loadLastSplit).mockReturnValue({ id: 'abc123', name: 'Weekend Trip' });
-    vi.mocked(getSplit).mockResolvedValue({
-      id: 'abc123',
-      name: 'Weekend Trip',
-      createdAt: '2026-01-01T00:00:00Z',
-      participants: [],
-      expenses: [],
-      settlement: null,
-    });
-
-    render(Home);
-
-    await waitFor(() => {
-      expect(screen.getByText('Dismiss')).toBeInTheDocument();
-    });
-
-    await fireEvent.click(screen.getByText('Dismiss'));
-
-    await waitFor(() => {
-      expect(clearLastSplit).toHaveBeenCalled();
-      expect(screen.queryByText('Resume your split')).not.toBeInTheDocument();
+    it('does not show captcha modal on page load', () => {
+      vi.mocked(hasValidToken).mockReturnValue(false);
+      render(Home);
+      expect(screen.queryByText('Human Verification')).not.toBeInTheDocument();
     });
   });
 });

--- a/src/main/doc/implementation/2026-04-03-Feature-rework-welcome-and-expense-modal.md
+++ b/src/main/doc/implementation/2026-04-03-Feature-rework-welcome-and-expense-modal.md
@@ -1,0 +1,62 @@
+# Feature: Rework Welcome Page and Expense Modal
+
+## What, Why and Constraints
+
+**What:** Three UX improvements from issue #94:
+1. The welcome page now stores and displays up to 10 recent splits (instead of 1), each with its own Resume/Dismiss action.
+2. The first-participant form has been removed from the welcome page — creating a split now only requires a name, then navigates directly to the participants page.
+3. The expense modal now shows Description before Amount.
+
+**Why:** The single "last split" resume card was limiting for users who work with multiple splits. The first-participant form on the home page was adding unnecessary friction to split creation. The description/amount order reflects natural input flow (name the expense first, then enter the cost).
+
+**Constraints:**
+- `saveLastSplit()` signature was kept identical so `Split.svelte` (the only other caller) required no changes.
+- The store key was renamed from `fairnsquare_lastSplit` (single object) to `fairnsquare_lastSplits` (array) — old stored data is silently ignored (parse fails gracefully, returns `[]`).
+- Recent splits are verified against the API on mount using `Promise.allSettled` — stale splits (404) are removed from storage automatically.
+
+## How
+
+### Files modified
+
+**`fairnsquare-app/src/main/webui/src/lib/stores/lastSplitStore.ts`**
+
+Complete rewrite:
+- `saveLastSplit(split)` — prepends to array, deduplicates by id, caps at 10
+- `loadLastSplits()` — returns `LastSplit[]` (new plural function)
+- `removeLastSplit(id)` — removes one specific split by id (replaces `clearLastSplit`)
+- `clearLastSplit` removed (no longer needed)
+
+**`fairnsquare-app/src/main/webui/src/routes/Home.svelte`**
+
+- Removed: participant name, nights, share fields; related state, validation, and `addParticipant` / `saveNightsDefault` calls
+- `doCreateSplit()` now only calls `createSplit()` then navigates to the participants page
+- Single resume card replaced by a list of recent splits (each with Resume + Dismiss)
+- Recent splits verified via `Promise.allSettled` on mount; stale ones auto-removed
+- Layout: Create Split form first, recent splits list below
+
+**`fairnsquare-app/src/main/webui/src/lib/components/expense/ExpenseEditModal.svelte`**
+
+- Description field moved before Amount field in the form template
+
+### Files modified (tests)
+
+**`fairnsquare-app/src/main/webui/src/lib/stores/lastSplitStore.test.ts`**
+
+Fully rewritten to cover the new API: `saveLastSplit`, `loadLastSplits`, `removeLastSplit` — including deduplication, cap-at-10, and stale-entry handling.
+
+**`fairnsquare-app/src/main/webui/src/routes/Home.test.ts`**
+
+Fully rewritten:
+- Removed all participant form tests and two-step create flow tests
+- Added tests for split-name-only form, simplified create flow, recent splits list, individual dismiss, stale split removal, and CAPTCHA integration
+
+## Tests
+
+| File | Tests | Coverage |
+|---|---|---|
+| `lastSplitStore.test.ts` | 11 | saveLastSplit (prepend, dedup, cap), loadLastSplits (empty/corrupt/not-array), removeLastSplit (found/not-found/empty) |
+| `Home.test.ts` | 18 | Form rendering (AC1), validation (AC2), create flow (AC3), recent splits list (AC4), individual dismiss (AC5), error handling (AC6), CAPTCHA (AC7) |
+| `EditExpenseModal.test.ts` | 47 | Existing — all pass, field-order swap had no impact |
+| `AddExpenseModal.test.ts` | 62 | Existing — all pass, field-order swap had no impact |
+
+**Total: 449 tests passing (full suite).**


### PR DESCRIPTION
## Summary

- **Recent splits list**: stores up to 10 visited splits in localStorage (was 1); home page shows them all with individual Resume/Dismiss; stale splits (404) are auto-removed on load
- **Simplified split creation**: removed the first-participant form from the home page — only split name required; navigates directly to the participants page after creation
- **Expense modal field order**: Description is now shown before Amount; initial focus follows the new order

## Test plan

- [x] `lastSplitStore.test.ts` — 11 tests (save/load/remove, dedup, cap at 10)
- [x] `Home.test.ts` — 18 tests (form rendering, validation, create flow, recent splits list, individual dismiss, error handling, CAPTCHA)
- [x] `AddExpenseModal.test.ts` — 62 tests, updated auto-focus assertion
- [x] Full test suite — 449 tests passing
- [ ] Manual: create a split → verify navigation goes straight to participants page
- [ ] Manual: visit several splits → return to home → verify recent list shows all of them
- [ ] Manual: open expense modal → verify description is focused first

Closes #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)