### PR TITLE
feat: add navigation tab bar to switch between split views (#93)

### DIFF
--- a/fairnsquare-app/src/main/webui/src/lib/components/ui/split-page-header/SplitPageHeader.svelte
+++ b/fairnsquare-app/src/main/webui/src/lib/components/ui/split-page-header/SplitPageHeader.svelte
@@ -1,18 +1,32 @@
 <script lang="ts">
   import type { Snippet } from 'svelte';
-  import { ArrowLeft, Share2 } from 'lucide-svelte';
+  import { Share2, LayoutDashboard, Users, Receipt, ArrowLeftRight } from 'lucide-svelte';
   import { Button } from '$lib/components/ui/button';
   import { addToast } from '$lib/stores/toastStore.svelte';
-  import { navigate } from '$lib/router';
+  import { navigate, route } from '$lib/router';
 
   interface Props {
     splitName: string;
     splitId: string;
-    showBackButton?: boolean;
     children?: Snippet;
   }
 
-  const { splitName, splitId, showBackButton = false, children }: Props = $props();
+  const { splitName, splitId, children }: Props = $props();
+
+  const activeTab = $derived.by(() => {
+    const path = route.pathname;
+    if (path.endsWith('/participants')) return 'participants';
+    if (path.endsWith('/expenses')) return 'expenses';
+    if (path.endsWith('/settlement')) return 'settlement';
+    return 'dashboard';
+  });
+
+  const tabs = [
+    { id: 'dashboard', label: 'Dashboard', icon: LayoutDashboard, path: () => `/splits/${splitId}` },
+    { id: 'participants', label: 'Participants', icon: Users, path: () => `/splits/${splitId}/participants` },
+    { id: 'expenses', label: 'Expenses', icon: Receipt, path: () => `/splits/${splitId}/expenses` },
+    { id: 'settlement', label: 'Settlement', icon: ArrowLeftRight, path: () => `/splits/${splitId}/settlement` },
+  ] as const;
 
   async function handleShare() {
     if (typeof window === 'undefined') return;
@@ -33,34 +47,43 @@
   }
 </script>
 
-<header class="w-full flex items-center justify-between">
-  <div class="flex items-center gap-2 min-w-0">
-    {#if showBackButton}
+<div class="w-full space-y-3">
+  <!-- Title row -->
+  <header class="w-full flex items-center justify-between">
+    <h1 class="text-lg font-bold text-primary break-words min-w-0">{splitName}</h1>
+    <div class="flex items-center gap-1 shrink-0">
+      {#if children}
+        {@render children()}
+      {/if}
       <Button
-        variant="ghost"
+        onclick={handleShare}
+        variant="outline"
         size="sm"
-        onclick={() => navigate(`/splits/${splitId}`)}
-        class="min-h-[44px] min-w-[44px] shrink-0"
-        aria-label="Back to dashboard"
+        class="min-h-[44px]"
+        aria-label="Share link"
       >
-        <ArrowLeft class="h-5 w-5" />
+        <Share2 class="h-4 w-4 mr-1" />
+        Share
       </Button>
-    {/if}
-    <h1 class="text-lg font-bold text-primary break-words">{splitName}</h1>
-  </div>
-  <div class="flex items-center gap-1 shrink-0">
-    {#if children}
-      {@render children()}
-    {/if}
-    <Button
-      onclick={handleShare}
-      variant="outline"
-      size="sm"
-      class="min-h-[44px]"
-      aria-label="Share link"
-    >
-      <Share2 class="h-4 w-4 mr-1" />
-      Share
-    </Button>
-  </div>
-</header>
+    </div>
+  </header>
+
+  <!-- Navigation tabs -->
+  <nav aria-label="Split navigation" class="flex border-b border-border">
+    {#each tabs as tab}
+      {@const isActive = activeTab === tab.id}
+      {@const Icon = tab.icon}
+      <button
+        onclick={() => navigate(tab.path())}
+        aria-current={isActive ? 'page' : undefined}
+        class="flex items-center gap-1.5 px-3 py-2 text-sm font-medium whitespace-nowrap transition-colors min-h-[44px]
+          {isActive
+            ? 'border-b-2 border-primary text-primary -mb-px'
+            : 'text-muted-foreground hover:text-foreground'}"
+      >
+        <Icon class="h-4 w-4 shrink-0" />
+        {tab.label}
+      </button>
+    {/each}
+  </nav>
+</div>

--- a/fairnsquare-app/src/main/webui/src/lib/components/ui/split-page-header/SplitPageHeader.test.ts
+++ b/fairnsquare-app/src/main/webui/src/lib/components/ui/split-page-header/SplitPageHeader.test.ts
@@ -1,12 +1,25 @@
+/**
+ * SplitPageHeader tests
+ * Issue #93: Add navigation menu to switch between split views
+ *
+ * AC1: All 4 navigation tabs are rendered
+ * AC2: Clicking a tab navigates to the correct route
+ * AC3: Active tab reflects the current pathname
+ * AC4: Share button works
+ * AC5: Split name is rendered
+ */
+
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/svelte';
 import SplitPageHeader from './SplitPageHeader.svelte';
+
+const mockRoute = vi.hoisted(() => ({ params: {}, pathname: '/splits/split-abc' }));
 
 vi.mock('$lib/router', () => ({
   p: vi.fn((path: string) => path),
   navigate: vi.fn(),
   isActive: vi.fn(),
-  route: { params: {}, pathname: '/' },
+  route: mockRoute,
 }));
 
 vi.mock('$lib/stores/toastStore.svelte', () => ({
@@ -19,75 +32,144 @@ import { addToast } from '$lib/stores/toastStore.svelte';
 const SPLIT_ID = 'split-abc';
 const SPLIT_NAME = 'Weekend in Paris';
 
+const defaultProps = { splitName: SPLIT_NAME, splitId: SPLIT_ID };
+
 describe('SplitPageHeader', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockRoute.pathname = `/splits/${SPLIT_ID}`;
   });
 
-  // --- Split name ---
+  // --- AC5: Split name ---
 
   it('renders the split name', () => {
-    render(SplitPageHeader, { props: { splitName: SPLIT_NAME, splitId: SPLIT_ID } });
-
+    render(SplitPageHeader, { props: defaultProps });
     expect(screen.getByText(SPLIT_NAME)).toBeInTheDocument();
   });
 
-  // --- Share button ---
+  // --- AC1: Navigation tabs rendered ---
 
-  it('renders a Share button', () => {
-    render(SplitPageHeader, { props: { splitName: SPLIT_NAME, splitId: SPLIT_ID } });
+  describe('Navigation tabs (AC1)', () => {
+    it('renders all 4 navigation tabs', () => {
+      render(SplitPageHeader, { props: defaultProps });
 
-    expect(screen.getByRole('button', { name: 'Share link' })).toBeInTheDocument();
-  });
+      expect(screen.getByRole('button', { name: /dashboard/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /participants/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /expenses/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /settlement/i })).toBeInTheDocument();
+    });
 
-  it('copies URL to clipboard and shows success toast when Share is clicked', async () => {
-    const mockWriteText = vi.fn().mockResolvedValue(undefined);
-    Object.assign(navigator, { clipboard: { writeText: mockWriteText } });
-
-    render(SplitPageHeader, { props: { splitName: SPLIT_NAME, splitId: SPLIT_ID } });
-
-    await fireEvent.click(screen.getByRole('button', { name: 'Share link' }));
-
-    await waitFor(() => {
-      expect(mockWriteText).toHaveBeenCalled();
-      expect(addToast).toHaveBeenCalledWith({ type: 'success', message: 'Link copied!' });
+    it('renders a nav landmark with aria-label', () => {
+      render(SplitPageHeader, { props: defaultProps });
+      expect(screen.getByRole('navigation', { name: 'Split navigation' })).toBeInTheDocument();
     });
   });
 
-  it('shows URL in toast when clipboard API fails', async () => {
-    const mockWriteText = vi.fn().mockRejectedValue(new Error('Clipboard denied'));
-    Object.assign(navigator, { clipboard: { writeText: mockWriteText } });
+  // --- AC2: Tab navigation ---
 
-    render(SplitPageHeader, { props: { splitName: SPLIT_NAME, splitId: SPLIT_ID } });
+  describe('Tab navigation (AC2)', () => {
+    it('navigates to the dashboard when Dashboard tab is clicked', async () => {
+      render(SplitPageHeader, { props: defaultProps });
 
-    await fireEvent.click(screen.getByRole('button', { name: 'Share link' }));
+      await fireEvent.click(screen.getByRole('button', { name: /dashboard/i }));
 
-    await waitFor(() => {
-      expect(addToast).toHaveBeenCalledWith(
-        expect.objectContaining({ message: expect.stringContaining('Share link:') }),
-      );
+      expect(navigate).toHaveBeenCalledWith(`/splits/${SPLIT_ID}`);
+    });
+
+    it('navigates to participants when Participants tab is clicked', async () => {
+      render(SplitPageHeader, { props: defaultProps });
+
+      await fireEvent.click(screen.getByRole('button', { name: /participants/i }));
+
+      expect(navigate).toHaveBeenCalledWith(`/splits/${SPLIT_ID}/participants`);
+    });
+
+    it('navigates to expenses when Expenses tab is clicked', async () => {
+      render(SplitPageHeader, { props: defaultProps });
+
+      await fireEvent.click(screen.getByRole('button', { name: /expenses/i }));
+
+      expect(navigate).toHaveBeenCalledWith(`/splits/${SPLIT_ID}/expenses`);
+    });
+
+    it('navigates to settlement when Settlement tab is clicked', async () => {
+      render(SplitPageHeader, { props: defaultProps });
+
+      await fireEvent.click(screen.getByRole('button', { name: /settlement/i }));
+
+      expect(navigate).toHaveBeenCalledWith(`/splits/${SPLIT_ID}/settlement`);
     });
   });
 
-  // --- Back button ---
+  // --- AC3: Active tab ---
 
-  it('does not render a back button by default', () => {
-    render(SplitPageHeader, { props: { splitName: SPLIT_NAME, splitId: SPLIT_ID } });
+  describe('Active tab (AC3)', () => {
+    it('marks Dashboard tab as active on the split dashboard route', () => {
+      mockRoute.pathname = `/splits/${SPLIT_ID}`;
+      render(SplitPageHeader, { props: defaultProps });
 
-    expect(screen.queryByRole('button', { name: 'Back to dashboard' })).not.toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /dashboard/i })).toHaveAttribute('aria-current', 'page');
+      expect(screen.getByRole('button', { name: /participants/i })).not.toHaveAttribute('aria-current');
+    });
+
+    it('marks Participants tab as active on the participants route', () => {
+      mockRoute.pathname = `/splits/${SPLIT_ID}/participants`;
+      render(SplitPageHeader, { props: defaultProps });
+
+      expect(screen.getByRole('button', { name: /participants/i })).toHaveAttribute('aria-current', 'page');
+      expect(screen.getByRole('button', { name: /dashboard/i })).not.toHaveAttribute('aria-current');
+    });
+
+    it('marks Expenses tab as active on the expenses route', () => {
+      mockRoute.pathname = `/splits/${SPLIT_ID}/expenses`;
+      render(SplitPageHeader, { props: defaultProps });
+
+      expect(screen.getByRole('button', { name: /expenses/i })).toHaveAttribute('aria-current', 'page');
+    });
+
+    it('marks Settlement tab as active on the settlement route', () => {
+      mockRoute.pathname = `/splits/${SPLIT_ID}/settlement`;
+      render(SplitPageHeader, { props: defaultProps });
+
+      expect(screen.getByRole('button', { name: /settlement/i })).toHaveAttribute('aria-current', 'page');
+    });
   });
 
-  it('renders a back button when showBackButton is true', () => {
-    render(SplitPageHeader, { props: { splitName: SPLIT_NAME, splitId: SPLIT_ID, showBackButton: true } });
+  // --- AC4: Share button ---
 
-    expect(screen.getByRole('button', { name: 'Back to dashboard' })).toBeInTheDocument();
-  });
+  describe('Share button (AC4)', () => {
+    it('renders a Share button', () => {
+      render(SplitPageHeader, { props: defaultProps });
+      expect(screen.getByRole('button', { name: 'Share link' })).toBeInTheDocument();
+    });
 
-  it('navigates to the split dashboard when back button is clicked', async () => {
-    render(SplitPageHeader, { props: { splitName: SPLIT_NAME, splitId: SPLIT_ID, showBackButton: true } });
+    it('copies URL to clipboard and shows success toast when Share is clicked', async () => {
+      const mockWriteText = vi.fn().mockResolvedValue(undefined);
+      Object.assign(navigator, { clipboard: { writeText: mockWriteText } });
 
-    await fireEvent.click(screen.getByRole('button', { name: 'Back to dashboard' }));
+      render(SplitPageHeader, { props: defaultProps });
 
-    expect(navigate).toHaveBeenCalledWith(`/splits/${SPLIT_ID}`);
+      await fireEvent.click(screen.getByRole('button', { name: 'Share link' }));
+
+      await waitFor(() => {
+        expect(mockWriteText).toHaveBeenCalled();
+        expect(addToast).toHaveBeenCalledWith({ type: 'success', message: 'Link copied!' });
+      });
+    });
+
+    it('shows URL in toast when clipboard API fails', async () => {
+      const mockWriteText = vi.fn().mockRejectedValue(new Error('Clipboard denied'));
+      Object.assign(navigator, { clipboard: { writeText: mockWriteText } });
+
+      render(SplitPageHeader, { props: defaultProps });
+
+      await fireEvent.click(screen.getByRole('button', { name: 'Share link' }));
+
+      await waitFor(() => {
+        expect(addToast).toHaveBeenCalledWith(
+          expect.objectContaining({ message: expect.stringContaining('Share link:') }),
+        );
+      });
+    });
   });
 });

--- a/fairnsquare-app/src/main/webui/src/routes/ExpenseList.svelte
+++ b/fairnsquare-app/src/main/webui/src/routes/ExpenseList.svelte
@@ -282,7 +282,7 @@
     </div>
   {:else if split}
     <!-- Header -->
-    <SplitPageHeader splitName={split.name} {splitId} showBackButton />
+    <SplitPageHeader splitName={split.name} {splitId} />
 
     <!-- Settled Banner -->
     {#if isSettled}

--- a/fairnsquare-app/src/main/webui/src/routes/ExpenseList.test.ts
+++ b/fairnsquare-app/src/main/webui/src/routes/ExpenseList.test.ts
@@ -192,15 +192,15 @@ describe('ExpenseList', () => {
       });
     });
 
-    it('navigates back to dashboard when back button clicked (AC 8)', async () => {
+    it('navigates to dashboard when Dashboard tab is clicked (AC 8)', async () => {
       vi.mocked(getSplit).mockResolvedValue(mockSplitWithExpenses);
       render(ExpenseList);
 
       await waitFor(() => {
-        expect(screen.getByRole('button', { name: 'Back to dashboard' })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /dashboard/i })).toBeInTheDocument();
       });
 
-      await fireEvent.click(screen.getByRole('button', { name: 'Back to dashboard' }));
+      await fireEvent.click(screen.getByRole('button', { name: /dashboard/i }));
       expect(navigate).toHaveBeenCalledWith('/splits/test-split-id-00001');
     });
 

--- a/fairnsquare-app/src/main/webui/src/routes/Participants.svelte
+++ b/fairnsquare-app/src/main/webui/src/routes/Participants.svelte
@@ -394,7 +394,7 @@
     </div>
   {:else if split}
     <!-- Header -->
-    <SplitPageHeader splitName={split.name} {splitId} showBackButton />
+    <SplitPageHeader splitName={split.name} {splitId} />
 
     <!-- Settled Banner -->
     {#if isSettled}

--- a/fairnsquare-app/src/main/webui/src/routes/Participants.test.ts
+++ b/fairnsquare-app/src/main/webui/src/routes/Participants.test.ts
@@ -155,16 +155,16 @@ describe('Participants', () => {
     });
   });
 
-  it('navigates back to dashboard when back button is clicked', async () => {
+  it('navigates to dashboard when Dashboard tab is clicked', async () => {
     vi.mocked(getSplit).mockResolvedValue(mockSplitEmpty);
 
     render(Participants);
 
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: 'Back to dashboard' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /dashboard/i })).toBeInTheDocument();
     });
 
-    await fireEvent.click(screen.getByRole('button', { name: 'Back to dashboard' }));
+    await fireEvent.click(screen.getByRole('button', { name: /dashboard/i }));
 
     expect(navigate).toHaveBeenCalledWith('/splits/test-split-id');
   });

--- a/fairnsquare-app/src/main/webui/src/routes/Settlement.svelte
+++ b/fairnsquare-app/src/main/webui/src/routes/Settlement.svelte
@@ -391,7 +391,7 @@
     </div>
   {:else if split}
     <!-- Header -->
-    <SplitPageHeader splitName={splitName} {splitId} showBackButton />
+    <SplitPageHeader splitName={splitName} {splitId} />
 
     {#if settlement}
       {#if displayBalances.length === 0}

--- a/fairnsquare-app/src/main/webui/src/routes/Settlement.test.ts
+++ b/fairnsquare-app/src/main/webui/src/routes/Settlement.test.ts
@@ -124,24 +124,24 @@ describe('Settlement', () => {
 
   // --- Header ---
 
-  it('displays header with back button and split name after load', async () => {
+  it('displays header with split name and nav tabs after load', async () => {
     render(Settlement);
 
     await waitFor(() => {
       expect(screen.getByText('Test Split')).toBeInTheDocument();
     });
 
-    expect(screen.getByRole('button', { name: 'Back to dashboard' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /dashboard/i })).toBeInTheDocument();
   });
 
-  it('navigates back to dashboard when back button is clicked', async () => {
+  it('navigates to dashboard when Dashboard tab is clicked', async () => {
     render(Settlement);
 
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: 'Back to dashboard' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /dashboard/i })).toBeInTheDocument();
     });
 
-    await fireEvent.click(screen.getByRole('button', { name: 'Back to dashboard' }));
+    await fireEvent.click(screen.getByRole('button', { name: /dashboard/i }));
     expect(navigate).toHaveBeenCalledWith('/splits/test-split-id');
   });
 

--- a/src/doc/rules/frontend-rules.md
+++ b/src/doc/rules/frontend-rules.md
@@ -75,6 +75,10 @@
 
 - When a component function resets state and then awaits an async call (e.g., `loadChallenge` after a wrong answer), do not clear `errorMessage` at the top of the function. Clear it only in the success branch, after the await resolves. Clearing it synchronously at the top batches the reset with the other state changes before the first `await`, so the DOM never shows the error — breaking both UX (error flashes invisibly) and `waitFor` assertions in tests. Always pattern: set error → call `loadFn` → inside `loadFn`, clear error on success.
 
+## Mutable Mock Objects in `vi.mock` Factories
+
+- When a `vi.mock` factory needs to reference a variable that is mutated between tests (e.g. `route.pathname` set in `beforeEach`), define it with `vi.hoisted(() => ({ ... }))` rather than a top-level `const`. Top-level variables are not yet initialized when `vi.mock` is hoisted, causing a `ReferenceError` at runtime.
+
 ## Scoping Queries When Multiple Elements Share the Same Label
 
 - When a component renders multiple buttons or elements with the same accessible name (e.g. two "Cancel" buttons — one in the modal footer, one inside a sub-banner), always scope `getByRole` queries using `within(container)` to avoid ambiguity errors. Use `within(screen.getByRole('alert'))`, `within(screen.getByRole('dialog'))`, or any distinct ARIA landmark to narrow the query to the relevant region.

--- a/src/main/doc/implementation/2026-04-03-Feature-split-navigation-menu.md
+++ b/src/main/doc/implementation/2026-04-03-Feature-split-navigation-menu.md
@@ -1,0 +1,48 @@
+# Feature: Split Navigation Menu
+
+## What, Why and Constraints
+
+**What:** Added a tab navigation bar to `SplitPageHeader` allowing users to switch between the four per-split views — Dashboard, Participants, Expenses, Settlement — without going back to the dashboard first. The active tab is highlighted based on the current route pathname. The back button (`showBackButton` prop) was removed since the Dashboard tab replaces it.
+
+**Why:** Issue #93 — there was no way to switch between views without navigating back to the dashboard first. This added unnecessary friction for users managing a split.
+
+**Constraints:**
+- Navigation only applies to per-split pages (not the home page)
+- `SplitPageHeader` already had `splitId` as a prop, so building the tab paths required no new data
+- Active tab derived from `route.pathname` suffix (no dependency on `isActive` from the router, which is not reliably testable with the current mock setup)
+- `<svelte:component>` deprecated in Svelte 5 runes mode — used `{@const Icon = tab.icon}` pattern instead
+
+## How
+
+### Files modified
+
+**`SplitPageHeader.svelte`**
+- Added `route` import from `$lib/router`
+- Added `activeTab` derived from `route.pathname` (suffix matching: `/participants`, `/expenses`, `/settlement`, else `dashboard`)
+- Added `tabs` array with id, label, icon, and path factory for each view
+- Added tab bar rendered below the title row using `aria-current="page"` for the active tab
+- Removed `showBackButton` prop and back button rendering
+
+**`ExpenseList.svelte`, `Participants.svelte`, `Settlement.svelte`**
+- Removed `showBackButton` from `<SplitPageHeader>` usage (3 files)
+
+### Files modified (tests)
+
+**`SplitPageHeader.test.ts`**
+- Used `vi.hoisted()` to define `mockRoute` (needed because `vi.mock` factories are hoisted above variable declarations)
+- Removed back-button tests (prop removed)
+- Added 14 tests covering: all 4 tabs rendered, nav landmark aria-label, correct `navigate` calls per tab, `aria-current="page"` on active tab per pathname, share button behaviour
+
+**`ExpenseList.test.ts`, `Participants.test.ts`, `Settlement.test.ts`**
+- Replaced "back button" tests with equivalent "Dashboard tab navigation" tests (4 tests updated)
+
+## Tests
+
+| File | Tests | Coverage |
+|---|---|---|
+| `SplitPageHeader.test.ts` | 14 | Tab rendering (AC1), navigate calls (AC2), active tab per pathname (AC3), share button (AC4), split name (AC5) |
+| `ExpenseList.test.ts` | updated | Dashboard tab replaces back button navigation test |
+| `Participants.test.ts` | updated | Dashboard tab replaces back button navigation test |
+| `Settlement.test.ts` | updated | 2 tests updated (header assertion + dashboard navigation) |
+
+**Total: 456 tests passing (full suite).**


### PR DESCRIPTION
## Summary

- Adds a **Dashboard / Participants / Expenses / Settlement** tab bar to `SplitPageHeader`, visible on all per-split pages
- Active tab is highlighted with `aria-current="page"` based on the current route pathname
- Removes the per-page back button (replaced by the Dashboard tab)
- Home page is unaffected

## Test plan

- [x] `SplitPageHeader.test.ts` — 14 tests (tab rendering, navigate calls, active tab per pathname, share button)
- [x] `ExpenseList.test.ts`, `Participants.test.ts`, `Settlement.test.ts` — back button tests replaced with Dashboard tab navigation tests
- [x] Full test suite — 456 tests passing
- [ ] Manual: navigate to any per-split page → verify all 4 tabs visible, active tab highlighted
- [ ] Manual: click each tab → verify navigation to correct view

Closes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)