### PR TITLE
fix: defer loading spinner 500ms and keep nav header stable (#103)

### DIFF
--- a/fairnsquare-app/src/main/webui/src/lib/stores/splitTitleCache.ts
+++ b/fairnsquare-app/src/main/webui/src/lib/stores/splitTitleCache.ts
@@ -1,0 +1,14 @@
+/**
+ * Session-level cache for split names.
+ * Populated when any per-split page loads, read on component mount so the
+ * header title is stable during page transitions instead of blinking blank.
+ */
+const cache = new Map<string, string>();
+
+export function getCachedSplitName(id: string): string {
+  return cache.get(id) ?? '';
+}
+
+export function setCachedSplitName(id: string, name: string): void {
+  cache.set(id, name);
+}

--- a/fairnsquare-app/src/main/webui/src/routes/ExpenseList.svelte
+++ b/fairnsquare-app/src/main/webui/src/routes/ExpenseList.svelte
@@ -11,13 +11,17 @@
   import { route, navigate } from '$lib/router';
   import { Plus, Pencil, Trash2, Receipt, ListFilter, X } from 'lucide-svelte';
   import SplitPageHeader from '$lib/components/ui/split-page-header/SplitPageHeader.svelte';
+  import { getCachedSplitName, setCachedSplitName } from '$lib/stores/splitTitleCache';
 
   const splitId = $derived(route.params.splitId || '');
 
   // State
   let split = $state<Split | null>(null);
+  let splitDisplayName = $state(getCachedSplitName(route.params.splitId || ''));
   const isSettled = $derived(split?.settlement != null);
   let isLoading = $state(true);
+  let showLoading = $state(false);
+  let loadingTimer: ReturnType<typeof setTimeout> | null = null;
 
   // Delete confirmation state
   let showDeleteConfirm = $state(false);
@@ -71,10 +75,15 @@
 
   async function loadSplit(id: string) {
     isLoading = true;
-    split = null;
+    showLoading = false;
+
+    if (loadingTimer) clearTimeout(loadingTimer);
+    loadingTimer = setTimeout(() => { showLoading = true; }, 500);
 
     try {
       split = await getSplit(id);
+      splitDisplayName = split.name;
+      setCachedSplitName(id, split.name);
     } catch (err) {
       const apiError = err as ApiError;
       if (apiError.status === 404 || apiError.status === 400) {
@@ -88,6 +97,8 @@
       }
     } finally {
       isLoading = false;
+      showLoading = false;
+      if (loadingTimer) { clearTimeout(loadingTimer); loadingTimer = null; }
     }
   }
 
@@ -262,7 +273,12 @@
 </script>
 
 <div class="flex flex-col items-center space-y-4 w-full max-w-[520px] mx-auto">
-  {#if isLoading}
+  <!-- Header always visible once splitId is known -->
+  {#if splitId}
+    <SplitPageHeader splitName={splitDisplayName} {splitId} />
+  {/if}
+
+  {#if showLoading}
     <div class="flex flex-col items-center justify-center py-12 space-y-4">
       <svg
         class="animate-spin h-8 w-8 text-primary"
@@ -280,9 +296,7 @@
       </svg>
       <p class="text-muted-foreground">Loading expenses...</p>
     </div>
-  {:else if split}
-    <!-- Header -->
-    <SplitPageHeader splitName={split.name} {splitId} />
+  {:else if !isLoading && split}
 
     <!-- Settled Banner -->
     {#if isSettled}

--- a/fairnsquare-app/src/main/webui/src/routes/ExpenseList.test.ts
+++ b/fairnsquare-app/src/main/webui/src/routes/ExpenseList.test.ts
@@ -227,11 +227,17 @@ describe('ExpenseList', () => {
       expect(screen.getByText(/€150\.00/)).toBeInTheDocument();
     });
 
-    it('shows loading state initially', () => {
+    it('shows loading spinner after 500ms delay', async () => {
+      vi.useFakeTimers();
       vi.mocked(getSplit).mockImplementation(() => new Promise(() => {}));
       render(ExpenseList);
 
+      expect(screen.queryByText('Loading expenses...')).not.toBeInTheDocument();
+
+      await vi.advanceTimersByTimeAsync(500);
+
       expect(screen.getByText('Loading expenses...')).toBeInTheDocument();
+      vi.useRealTimers();
     });
   });
 

--- a/fairnsquare-app/src/main/webui/src/routes/Participants.svelte
+++ b/fairnsquare-app/src/main/webui/src/routes/Participants.svelte
@@ -30,17 +30,21 @@
     },
   };
   import SplitPageHeader from '$lib/components/ui/split-page-header/SplitPageHeader.svelte';
+  import { getCachedSplitName, setCachedSplitName } from '$lib/stores/splitTitleCache';
   import { tick } from 'svelte';
 
   const splitId = $derived(route.params.splitId || '');
 
   // State
   let split = $state<Split | null>(null);
+  let splitDisplayName = $state(getCachedSplitName(route.params.splitId || ''));
   const sortedParticipants = $derived(
     split?.participants.slice().sort((a, b) => a.name.localeCompare(b.name)) ?? []
   );
   const isSettled = $derived(split?.settlement != null);
   let isLoading = $state(true);
+  let showLoading = $state(false);
+  let loadingTimer: ReturnType<typeof setTimeout> | null = null;
 
   // Add Participant form state
   let showAddForm = $state(false);
@@ -86,10 +90,15 @@
 
   async function loadSplit(id: string) {
     isLoading = true;
-    split = null;
+    showLoading = false;
+
+    if (loadingTimer) clearTimeout(loadingTimer);
+    loadingTimer = setTimeout(() => { showLoading = true; }, 500);
 
     try {
       split = await getSplit(id);
+      splitDisplayName = split.name;
+      setCachedSplitName(id, split.name);
     } catch (err) {
       const apiError = err as ApiError;
       if (apiError.status === 404 || apiError.status === 400) {
@@ -103,6 +112,8 @@
       }
     } finally {
       isLoading = false;
+      showLoading = false;
+      if (loadingTimer) { clearTimeout(loadingTimer); loadingTimer = null; }
     }
   }
 
@@ -374,7 +385,12 @@
 </script>
 
 <div class="flex flex-col items-center space-y-4 w-full max-w-[520px] mx-auto">
-  {#if isLoading}
+  <!-- Header always visible once splitId is known -->
+  {#if splitId}
+    <SplitPageHeader splitName={splitDisplayName} {splitId} />
+  {/if}
+
+  {#if showLoading}
     <div class="flex flex-col items-center justify-center py-12 space-y-4">
       <svg
         class="animate-spin h-8 w-8 text-primary"
@@ -392,9 +408,7 @@
       </svg>
       <p class="text-muted-foreground">Loading participants...</p>
     </div>
-  {:else if split}
-    <!-- Header -->
-    <SplitPageHeader splitName={split.name} {splitId} />
+  {:else if !isLoading && split}
 
     <!-- Settled Banner -->
     {#if isSettled}

--- a/fairnsquare-app/src/main/webui/src/routes/Participants.test.ts
+++ b/fairnsquare-app/src/main/webui/src/routes/Participants.test.ts
@@ -98,11 +98,17 @@ describe('Participants', () => {
 
   // --- Loading State ---
 
-  it('shows loading state initially', () => {
+  it('shows loading spinner after 500ms delay', async () => {
+    vi.useFakeTimers();
     vi.mocked(getSplit).mockImplementation(() => new Promise(() => {}));
     render(Participants);
 
+    expect(screen.queryByText('Loading participants...')).not.toBeInTheDocument();
+
+    await vi.advanceTimersByTimeAsync(500);
+
     expect(screen.getByText('Loading participants...')).toBeInTheDocument();
+    vi.useRealTimers();
   });
 
   // --- Page Header ---

--- a/fairnsquare-app/src/main/webui/src/routes/Settlement.svelte
+++ b/fairnsquare-app/src/main/webui/src/routes/Settlement.svelte
@@ -8,14 +8,17 @@
   import { addToast } from '$lib/stores/toastStore.svelte';
   import { route, navigate } from '$lib/router';
   import SplitPageHeader from '$lib/components/ui/split-page-header/SplitPageHeader.svelte';
+  import { getCachedSplitName, setCachedSplitName } from '$lib/stores/splitTitleCache';
 
   const splitId = $derived(route.params.splitId || '');
 
   // State
   let settlement = $state<Settlement | null>(null);
   let split = $state<Split | null>(null);
-  let splitName = $state('');
+  let splitName = $state(getCachedSplitName(route.params.splitId || ''));
   let isLoading = $state(true);
+  let showLoading = $state(false);
+  let loadingTimer: ReturnType<typeof setTimeout> | null = null;
   let showReimbursements = $state(false);
   let isUnsettling = $state(false);
   let isUpdatingGroup = $state(false);
@@ -120,13 +123,18 @@
 
   async function loadSettlement(id: string) {
     isLoading = true;
+    showLoading = false;
     settlement = null;
     showReimbursements = false;
+
+    if (loadingTimer) clearTimeout(loadingTimer);
+    loadingTimer = setTimeout(() => { showLoading = true; }, 500);
 
     try {
       const splitData = await getSplit(id);
       split = splitData;
       splitName = splitData.name;
+      setCachedSplitName(id, splitData.name);
 
       // Derive balances from participant computed fields (always available, no POST needed).
       const balances = splitData.participants.map(p => ({
@@ -153,6 +161,8 @@
       });
     } finally {
       isLoading = false;
+      showLoading = false;
+      if (loadingTimer) { clearTimeout(loadingTimer); loadingTimer = null; }
     }
   }
 
@@ -371,7 +381,12 @@
 </script>
 
 <div class="flex flex-col items-center space-y-4 w-full max-w-[520px] mx-auto">
-  {#if isLoading}
+  <!-- Header always visible once splitId is known -->
+  {#if splitId}
+    <SplitPageHeader {splitName} {splitId} />
+  {/if}
+
+  {#if showLoading}
     <div class="flex flex-col items-center justify-center py-12 space-y-4">
       <svg
         class="animate-spin h-8 w-8 text-primary"
@@ -389,9 +404,7 @@
       </svg>
       <p class="text-muted-foreground">Loading settlement...</p>
     </div>
-  {:else if split}
-    <!-- Header -->
-    <SplitPageHeader splitName={splitName} {splitId} />
+  {:else if !isLoading && split}
 
     {#if settlement}
       {#if displayBalances.length === 0}

--- a/fairnsquare-app/src/main/webui/src/routes/Settlement.test.ts
+++ b/fairnsquare-app/src/main/webui/src/routes/Settlement.test.ts
@@ -115,11 +115,17 @@ describe('Settlement', () => {
 
   // --- Loading State ---
 
-  it('shows loading state initially', () => {
+  it('shows loading spinner after 500ms delay', async () => {
+    vi.useFakeTimers();
     vi.mocked(getSplit).mockImplementation(() => new Promise(() => {}));
     render(Settlement);
 
+    expect(screen.queryByText('Loading settlement...')).not.toBeInTheDocument();
+
+    await vi.advanceTimersByTimeAsync(500);
+
     expect(screen.getByText('Loading settlement...')).toBeInTheDocument();
+    vi.useRealTimers();
   });
 
   // --- Header ---

--- a/fairnsquare-app/src/main/webui/src/routes/Split.svelte
+++ b/fairnsquare-app/src/main/webui/src/routes/Split.svelte
@@ -9,6 +9,7 @@
   import { addToast } from '$lib/stores/toastStore.svelte';
   import { route, navigate } from '$lib/router';
   import { saveLastSplit } from '$lib/stores/lastSplitStore';
+  import { getCachedSplitName, setCachedSplitName } from '$lib/stores/splitTitleCache';
   import ParticipantSummaryCard from '$lib/components/participant/ParticipantSummaryCard.svelte';
   import SplitPageHeader from '$lib/components/ui/split-page-header/SplitPageHeader.svelte';
 
@@ -17,7 +18,10 @@
 
   // State
   let split = $state<Split | null>(null);
+  let splitDisplayName = $state(getCachedSplitName(route.params.splitId || ''));
   let isLoading = $state(true);
+  let showLoading = $state(false);
+  let loadingTimer: ReturnType<typeof setTimeout> | null = null;
   let error = $state<string | null>(null);
 
   // Expense summary stats
@@ -41,11 +45,16 @@
 
   async function loadSplit(id: string) {
     isLoading = true;
+    showLoading = false;
     error = null;
-    split = null;
+
+    if (loadingTimer) clearTimeout(loadingTimer);
+    loadingTimer = setTimeout(() => { showLoading = true; }, 500);
 
     try {
       split = await getSplit(id);
+      splitDisplayName = split.name;
+      setCachedSplitName(id, split.name);
       saveLastSplit({ id: split.id, name: split.name });
     } catch (err) {
       const apiError = err as ApiError;
@@ -57,6 +66,8 @@
       }
     } finally {
       isLoading = false;
+      showLoading = false;
+      if (loadingTimer) { clearTimeout(loadingTimer); loadingTimer = null; }
     }
   }
 
@@ -71,8 +82,13 @@
 </script>
 
 <div class="flex flex-col items-center space-y-4 w-full max-w-[520px] mx-auto">
-  {#if isLoading}
-    <!-- Loading State -->
+  <!-- Header always visible once splitId is known -->
+  {#if splitId}
+    <SplitPageHeader splitName={splitDisplayName} {splitId} />
+  {/if}
+
+  {#if showLoading}
+    <!-- Loading State (deferred 500ms to avoid flash) -->
     <div class="flex flex-col items-center justify-center py-12 space-y-4">
       <svg class="animate-spin h-8 w-8 text-primary" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
         <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
@@ -95,10 +111,7 @@
       </Card.Content>
     </Card.Root>
 
-  {:else if split}
-    <!-- Dashboard Header -->
-    <SplitPageHeader splitName={split.name} {splitId} />
-
+  {:else if !isLoading && split}
     <!-- Expense Summary Card (clickable → navigates to expense list) -->
     <section class="w-full">
       <button

--- a/fairnsquare-app/src/main/webui/src/routes/Split.test.ts
+++ b/fairnsquare-app/src/main/webui/src/routes/Split.test.ts
@@ -38,11 +38,17 @@ describe('Split', () => {
 
   // --- Loading / Error / 404 States ---
 
-  it('shows loading state initially', () => {
+  it('shows loading spinner after 500ms delay', async () => {
+    vi.useFakeTimers();
     vi.mocked(getSplit).mockImplementation(() => new Promise(() => {}));
     render(Split);
 
+    expect(screen.queryByText('Loading split...')).not.toBeInTheDocument();
+
+    await vi.advanceTimersByTimeAsync(500);
+
     expect(screen.getByText('Loading split...')).toBeInTheDocument();
+    vi.useRealTimers();
   });
 
   it('automatically redirects to home when split not found (404)', async () => {

--- a/src/main/doc/implementation/2026-04-04-Bugfix-loading-state-flash-and-scope.md
+++ b/src/main/doc/implementation/2026-04-04-Bugfix-loading-state-flash-and-scope.md
@@ -1,0 +1,57 @@
+# Bugfix: Loading State Flash and Scope
+
+## What, Why and Constraints
+
+**What:** Fixed two UX problems with the loading indicator on per-split pages (Split dashboard, Participants, ExpenseList, Settlement):
+
+1. **Loading flash** — the spinner appeared immediately on every page transition, even when the API responded in under 500ms. Fixed by deferring `showLoading` to `true` only after a 500ms timer.
+2. **Full-page loading scope** — the loading block replaced the entire page including the navigation header. Fixed by always rendering `SplitPageHeader` outside the loading block, using `splitId` (available immediately from route params).
+3. **Title blink** — each per-split page is a separate Svelte component that mounts fresh with no split name. Navigating between tabs caused the title to flash blank on every mount. Fixed with a session-level `splitTitleCache` (plain Map) that persists the name across component re-mounts within the same session.
+
+**Why:** Issue #103 — the full-page spinner on every tab switch was jarring, even for fast loads. The header disappearing during loading also removed the navigation context from the user.
+
+**Constraints:**
+- `splitId` is always available from `route.params.splitId` — safe to pass to `SplitPageHeader` immediately.
+- Each tab is a separate Svelte component with its own `split = $state(null)` — name cannot persist between mounts without an external store. A session-level Map (`splitTitleCache.ts`) is the minimal solution.
+- `split` is also no longer reset to `null` on reload — prevents blink when reloading within the same component. Content is guarded by `!isLoading` to prevent stale data from rendering.
+- The timer must be cleared on both success and error paths to avoid stale state.
+
+## How
+
+### Files modified
+
+All 4 per-split route components received the same treatment:
+
+**`Split.svelte`, `Participants.svelte`, `ExpenseList.svelte`, `Settlement.svelte`**
+- Added `showLoading = $state(false)` and `loadingTimer` alongside existing `isLoading`
+- In `loadSplit()` / `loadSettlement()`: set `showLoading = false` at start, start a 500ms `setTimeout` that sets `showLoading = true`, clear timer and reset `showLoading = false` in `finally`
+- Added `splitDisplayName = $state(getCachedSplitName(...))` — initialized from cache on mount, so the last known name is immediately available
+- In `loadSplit`/`loadSettlement`: set `splitDisplayName`/`splitName` and call `setCachedSplitName()` on success
+- Removed `split = null` at the start of `loadSplit` — also prevents blink when reloading within the same component
+- Restructured template: `SplitPageHeader` moved above the `{#if ...}` block, always rendered when `splitId` is set
+- `{#if isLoading}` in template replaced with `{#if showLoading}` — spinner only shown after 500ms
+- Content guard changed from `{:else if split}` to `{:else if !isLoading && split}` — prevents stale content from rendering while loading
+
+**`src/lib/stores/splitTitleCache.ts`** (new)
+- Plain module-level `Map<string, string>` — no reactivity, no localStorage, no deps
+- Exports `getCachedSplitName(id)` and `setCachedSplitName(id, name)`
+
+### Files modified (tests)
+
+**`Split.test.ts`, `Participants.test.ts`, `ExpenseList.test.ts`, `Settlement.test.ts`**
+- Updated `shows loading state initially` → `shows loading spinner after 500ms delay`
+- Tests now use `vi.useFakeTimers()` + `vi.advanceTimersByTimeAsync(500)` to verify:
+  1. Spinner is NOT shown immediately after render
+  2. Spinner IS shown after 500ms with a pending API call
+- `vi.useRealTimers()` called at end of each test to restore timer behaviour
+
+## Tests
+
+| File | Tests | Coverage |
+|---|---|---|
+| `Split.test.ts` | updated (1) | Loading spinner deferred 500ms |
+| `Participants.test.ts` | updated (1) | Loading spinner deferred 500ms |
+| `ExpenseList.test.ts` | updated (1) | Loading spinner deferred 500ms |
+| `Settlement.test.ts` | updated (1) | Loading spinner deferred 500ms |
+
+**Total: 458 tests passing (full suite).**


### PR DESCRIPTION
## Summary
- Loading spinner now deferred 500ms — no flash for fast API responses
- Navigation header always visible during loading (scoped to content area only)
- Split name no longer blinks on tab switches — session-level `splitTitleCache` pre-populates the title on mount

## Test plan
- [ ] All 458 tests pass (`npx vitest run`)
- [ ] Switching between tabs (Home / Participants / Expenses / Settlement): header stays visible and title is stable
- [ ] On a slow connection: spinner appears after ~500ms, not immediately
- [ ] Fast API response: no spinner flash at all

🤖 Generated with [Claude Code](https://claude.com/claude-code)