### PR TITLE
feat: add Single/Family participant buttons with Members field (#88)

### DIFF
--- a/fairnsquare-app/src/main/webui/src/routes/Home.svelte
+++ b/fairnsquare-app/src/main/webui/src/routes/Home.svelte
@@ -85,7 +85,7 @@
         return;
       }
       const split = await createSplit({ name: splitName.trim() }, { [CAPTCHA_TOKEN_HEADER]: token });
-      navigate('/splits/:splitId/participants', { params: { splitId: split.id }, search: { addParticipant: 'true' } });
+      navigate('/splits/:splitId/participants', { params: { splitId: split.id } });
     } catch (err) {
       const apiError = err as ApiError;
       if (apiError.status === 401) {

--- a/fairnsquare-app/src/main/webui/src/routes/Home.test.ts
+++ b/fairnsquare-app/src/main/webui/src/routes/Home.test.ts
@@ -149,7 +149,6 @@ describe('Home', () => {
         );
         expect(navigate).toHaveBeenCalledWith('/splits/:splitId/participants', {
           params: { splitId: 'abc123' },
-          search: { addParticipant: 'true' },
         });
       });
     });

--- a/fairnsquare-app/src/main/webui/src/routes/Participants.svelte
+++ b/fairnsquare-app/src/main/webui/src/routes/Participants.svelte
@@ -17,7 +17,7 @@
   import { Plus, Wallet, Receipt, TrendingUp, TrendingDown, Minus, Info, X, Users } from 'lucide-svelte';
 
   // Field info modal state (add form)
-  let activeFieldInfo = $state<'nights' | 'share' | null>(null);
+  let activeFieldInfo = $state<'nights' | 'share' | 'members' | null>(null);
 
   const fieldInfo = {
     nights: {
@@ -27,6 +27,10 @@
     share: {
       title: 'Share',
       description: `The number of persons this participant represents.\n\nA solo traveller has a share of 1. A couple sharing costs would have a share of 2, a family of 3 would use 3, etc.\n\nUsed in "By Night" mode (nights × share) and "By Share" mode (share only) to calculate each participant's proportional contribution.\n\nExample: a couple (share 2) staying 3 nights counts as 6 night-shares, compared to 3 night-shares for a solo person staying the same time.`,
+    },
+    members: {
+      title: 'Members',
+      description: `The number of people in this family group.\n\nAdults count as 1 each. Children can count for 0.5 to reflect their lower consumption.\n\nExample: a family of 2 adults and 2 children staying 7 nights → 3 members (2 × 1 + 2 × 0.5).\n\nIf one parent leaves early (e.g. stays only 3 nights), add them as a separate single participant with 3 nights and a share of 1. The rest of the family can then be entered with fewer members.`,
     },
   };
   import SplitPageHeader from '$lib/components/ui/split-page-header/SplitPageHeader.svelte';
@@ -47,12 +51,13 @@
   let loadingTimer: ReturnType<typeof setTimeout> | null = null;
 
   // Add Participant form state
-  let showAddForm = $state(false);
+  let addMode = $state<'single' | 'family' | null>(null);
   let nameInputEl = $state<HTMLInputElement | null>(null);
   let formName = $state('');
   let formNights = $state(1);
   let formShare = $state(1);
-  let validationErrors = $state<{name?: string; nights?: string; share?: string}>({});
+  let formMembers = $state(1);
+  let validationErrors = $state<{name?: string; nights?: string; share?: string; members?: string}>({});
   let isSubmitting = $state(false);
 
   // Edit Participant state
@@ -74,17 +79,6 @@
   $effect(() => {
     if (splitId) {
       loadSplit(splitId);
-    }
-  });
-
-  // Auto-open add form when navigated from the Home creation flow
-  $effect(() => {
-    if (route.search?.addParticipant) {
-      handleShowAddForm();
-      // Remove the param from the URL without triggering re-navigation
-      const url = new URL(window.location.href);
-      url.searchParams.delete('addParticipant');
-      window.history.replaceState(null, '', url.toString());
     }
   });
 
@@ -175,8 +169,8 @@
   }
 
   // Add Participant handlers
-  async function handleShowAddForm() {
-    showAddForm = true;
+  async function handleShowSingleForm() {
+    addMode = 'single';
     formName = '';
     formNights = loadNightsDefault();
     formShare = 1;
@@ -185,11 +179,22 @@
     nameInputEl?.focus();
   }
 
+  async function handleShowFamilyForm() {
+    addMode = 'family';
+    formName = '';
+    formNights = loadNightsDefault();
+    formMembers = 1;
+    validationErrors = {};
+    await tick();
+    nameInputEl?.focus();
+  }
+
   function handleCancelAddForm() {
-    showAddForm = false;
+    addMode = null;
     formName = '';
     formNights = 1;
     formShare = 1;
+    formMembers = 1;
     validationErrors = {};
   }
 
@@ -227,8 +232,18 @@
     validationErrors = { ...validationErrors, share: error };
   }
 
+  function validateMembersOnInput() {
+    let error: string | undefined;
+    if (formMembers < 0.5) {
+      error = 'Must be at least 0.5';
+    } else if (formMembers > 50) {
+      error = 'Cannot exceed 50';
+    }
+    validationErrors = { ...validationErrors, members: error };
+  }
+
   function validateAddForm(): boolean {
-    const errors: {name?: string; nights?: string; share?: string} = {};
+    const errors: {name?: string; nights?: string; share?: string; members?: string} = {};
 
     if (!formName.trim()) {
       errors.name = 'Name is required';
@@ -244,10 +259,18 @@
       errors.nights = 'Nights cannot exceed 365';
     }
 
-    if (formShare < 0.5) {
-      errors.share = 'Must be at least 0.5';
-    } else if (formShare > 50) {
-      errors.share = 'Cannot exceed 50';
+    if (addMode === 'family') {
+      if (formMembers < 0.5) {
+        errors.members = 'Must be at least 0.5';
+      } else if (formMembers > 50) {
+        errors.members = 'Cannot exceed 50';
+      }
+    } else {
+      if (formShare < 0.5) {
+        errors.share = 'Must be at least 0.5';
+      } else if (formShare > 50) {
+        errors.share = 'Cannot exceed 50';
+      }
     }
 
     validationErrors = errors;
@@ -262,18 +285,19 @@
     try {
       const addedName = formName.trim();
       const addedNights = formNights;
-      const addedShare = formShare;
+      const addedShare = addMode === 'family' ? formMembers : formShare;
       await addParticipant(splitId, {
         name: addedName,
-        nights: formNights,
-        share: formShare,
+        nights: addedNights,
+        share: addedShare,
       });
 
-      saveNightsDefault(formNights);
-      showAddForm = false;
+      saveNightsDefault(addedNights);
+      addMode = null;
       formName = '';
       formNights = 1;
       formShare = 1;
+      formMembers = 1;
       validationErrors = {};
       await loadSplit(splitId);
 
@@ -426,12 +450,14 @@
     <!-- Participants Summary Card -->
     <ParticipantSummaryCard participants={split.participants} showTitle={false} />
 
-    <!-- Add Participant Form / Button (hidden when settled) -->
-    {#if !isSettled && showAddForm}
+    <!-- Add Participant Form / Buttons (hidden when settled) -->
+    {#if !isSettled && addMode !== null}
       <Card.Root class="w-full">
         <Card.Content class="py-4">
           <form onsubmit={(e) => { e.preventDefault(); handleAddParticipant(); }} class="space-y-3">
-            <p class="text-sm font-medium text-teal-700">New Participant</p>
+            <p class="text-sm font-medium text-teal-700">
+              {addMode === 'family' ? 'New Family' : 'New Participant'}
+            </p>
 
             <div class="space-y-2">
               <Label for="participant-name">Name</Label>
@@ -473,28 +499,53 @@
                 {/if}
               </div>
 
-              <div class="space-y-2 flex-1">
-                <div class="flex items-center gap-1">
-                  <Label for="participant-share">Share</Label>
-                  <button type="button" onclick={() => { activeFieldInfo = 'share'; }} class="p-0.5 rounded-full hover:bg-muted text-muted-foreground" aria-label="Info about Share">
-                    <Info class="h-3.5 w-3.5" />
-                  </button>
+              {#if addMode === 'family'}
+                <div class="space-y-2 flex-1">
+                  <div class="flex items-center gap-1">
+                    <Label for="participant-members">Members</Label>
+                    <button type="button" onclick={() => { activeFieldInfo = 'members'; }} class="p-0.5 rounded-full hover:bg-muted text-muted-foreground" aria-label="Info about Members">
+                      <Info class="h-3.5 w-3.5" />
+                    </button>
+                  </div>
+                  <Input
+                    id="participant-members"
+                    type="number"
+                    step="0.5"
+                    min="0.5"
+                    max="50"
+                    bind:value={formMembers}
+                    oninput={validateMembersOnInput}
+                    class="min-h-[44px]"
+                    disabled={isSubmitting}
+                  />
+                  {#if validationErrors.members}
+                    <p class="text-sm text-destructive">{validationErrors.members}</p>
+                  {/if}
                 </div>
-                <Input
-                  id="participant-share"
-                  type="number"
-                  step="0.5"
-                  min="0.5"
-                  max="50"
-                  bind:value={formShare}
-                  oninput={validateShareOnInput}
-                  class="min-h-[44px]"
-                  disabled={isSubmitting}
-                />
-                {#if validationErrors.share}
-                  <p class="text-sm text-destructive">{validationErrors.share}</p>
-                {/if}
-              </div>
+              {:else}
+                <div class="space-y-2 flex-1">
+                  <div class="flex items-center gap-1">
+                    <Label for="participant-share">Share</Label>
+                    <button type="button" onclick={() => { activeFieldInfo = 'share'; }} class="p-0.5 rounded-full hover:bg-muted text-muted-foreground" aria-label="Info about Share">
+                      <Info class="h-3.5 w-3.5" />
+                    </button>
+                  </div>
+                  <Input
+                    id="participant-share"
+                    type="number"
+                    step="0.5"
+                    min="0.5"
+                    max="50"
+                    bind:value={formShare}
+                    oninput={validateShareOnInput}
+                    class="min-h-[44px]"
+                    disabled={isSubmitting}
+                  />
+                  {#if validationErrors.share}
+                    <p class="text-sm text-destructive">{validationErrors.share}</p>
+                  {/if}
+                </div>
+              {/if}
             </div>
 
             <div class="flex gap-2">
@@ -509,19 +560,27 @@
         </Card.Content>
       </Card.Root>
     {:else if !isSettled}
-      <Button
-        onclick={handleShowAddForm}
-        variant="outline"
-        class="w-full min-h-[44px]"
-      >
-        <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 mr-1" viewBox="0 0 20 20" fill="currentColor">
-          <path fill-rule="evenodd" d="M10 3a1 1 0 011 1v5h5a1 1 0 110 2h-5v5a1 1 0 11-2 0v-5H4a1 1 0 110-2h5V4a1 1 0 011-1z" clip-rule="evenodd" />
-        </svg>
-        Add Participant
-      </Button>
+      <div class="flex gap-2 w-full">
+        <Button
+          onclick={handleShowSingleForm}
+          variant="outline"
+          class="flex-1 min-h-[44px]"
+        >
+          <Plus class="h-4 w-4 mr-1" />
+          Single
+        </Button>
+        <Button
+          onclick={handleShowFamilyForm}
+          variant="outline"
+          class="flex-1 min-h-[44px]"
+        >
+          <Users class="h-4 w-4 mr-1" />
+          Family
+        </Button>
+      </div>
     {/if}
 
-    {#if sortedParticipants.length === 0 && !showAddForm}
+    {#if sortedParticipants.length === 0 && addMode === null}
       <p class="text-muted-foreground text-center py-4">No participants yet</p>
     {/if}
 

--- a/fairnsquare-app/src/main/webui/src/routes/Participants.test.ts
+++ b/fairnsquare-app/src/main/webui/src/routes/Participants.test.ts
@@ -427,26 +427,27 @@ describe('Participants', () => {
   // --- Add Participant ---
 
   describe('Add Participant', () => {
-    it('shows Add Participant button', async () => {
+    it('shows Single and Family buttons', async () => {
       vi.mocked(getSplit).mockResolvedValue(mockSplitEmpty);
 
       render(Participants);
 
       await waitFor(() => {
-        expect(screen.getByRole('button', { name: /Add Participant/i })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Single' })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Family' })).toBeInTheDocument();
       });
     });
 
-    it('shows form when Add Participant button is clicked', async () => {
+    it('shows form when Single button is clicked', async () => {
       vi.mocked(getSplit).mockResolvedValue(mockSplitEmpty);
 
       render(Participants);
 
       await waitFor(() => {
-        expect(screen.getByRole('button', { name: /Add Participant/i })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Single' })).toBeInTheDocument();
       });
 
-      await fireEvent.click(screen.getByRole('button', { name: /Add Participant/i }));
+      await fireEvent.click(screen.getByRole('button', { name: 'Single' }));
 
       expect(screen.getByLabelText('Name')).toBeInTheDocument();
       expect(screen.getByLabelText('Nights')).toBeInTheDocument();
@@ -460,10 +461,10 @@ describe('Participants', () => {
       render(Participants);
 
       await waitFor(() => {
-        expect(screen.getByRole('button', { name: /Add Participant/i })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Single' })).toBeInTheDocument();
       });
 
-      await fireEvent.click(screen.getByRole('button', { name: /Add Participant/i }));
+      await fireEvent.click(screen.getByRole('button', { name: 'Single' }));
 
       const nightsInput = screen.getByLabelText('Nights') as HTMLInputElement;
       expect(nightsInput.value).toBe('1');
@@ -476,10 +477,10 @@ describe('Participants', () => {
       render(Participants);
 
       await waitFor(() => {
-        expect(screen.getByRole('button', { name: /Add Participant/i })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Single' })).toBeInTheDocument();
       });
 
-      await fireEvent.click(screen.getByRole('button', { name: /Add Participant/i }));
+      await fireEvent.click(screen.getByRole('button', { name: 'Single' }));
 
       const nightsInput = screen.getByLabelText('Nights') as HTMLInputElement;
       expect(nightsInput.value).toBe('3');
@@ -491,10 +492,10 @@ describe('Participants', () => {
       render(Participants);
 
       await waitFor(() => {
-        expect(screen.getByRole('button', { name: /Add Participant/i })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Single' })).toBeInTheDocument();
       });
 
-      await fireEvent.click(screen.getByRole('button', { name: /Add Participant/i }));
+      await fireEvent.click(screen.getByRole('button', { name: 'Single' }));
       await fireEvent.click(screen.getByRole('button', { name: 'Add' }));
 
       expect(screen.getByText('Name is required')).toBeInTheDocument();
@@ -510,7 +511,7 @@ describe('Participants', () => {
         expect(screen.getByText('Alice')).toBeInTheDocument();
       });
 
-      await fireEvent.click(screen.getByRole('button', { name: /Add Participant/i }));
+      await fireEvent.click(screen.getByRole('button', { name: 'Single' }));
       await fireEvent.input(screen.getByLabelText('Name'), { target: { value: 'Alice' } });
 
       expect(screen.getByText('A participant with this name already exists')).toBeInTheDocument();
@@ -526,7 +527,7 @@ describe('Participants', () => {
         expect(screen.getByText('Alice')).toBeInTheDocument();
       });
 
-      await fireEvent.click(screen.getByRole('button', { name: /Add Participant/i }));
+      await fireEvent.click(screen.getByRole('button', { name: 'Single' }));
       await fireEvent.input(screen.getByLabelText('Name'), { target: { value: 'A'.repeat(51) } });
 
       expect(screen.getByText('Name cannot exceed 50 characters')).toBeInTheDocument();
@@ -542,7 +543,7 @@ describe('Participants', () => {
         expect(screen.getByText('Alice')).toBeInTheDocument();
       });
 
-      await fireEvent.click(screen.getByRole('button', { name: /Add Participant/i }));
+      await fireEvent.click(screen.getByRole('button', { name: 'Single' }));
       await fireEvent.input(screen.getByLabelText('Name'), { target: { value: '' } });
 
       expect(screen.queryByText('Name is required')).not.toBeInTheDocument();
@@ -557,7 +558,7 @@ describe('Participants', () => {
         expect(screen.getByText('Alice')).toBeInTheDocument();
       });
 
-      await fireEvent.click(screen.getByRole('button', { name: /Add Participant/i }));
+      await fireEvent.click(screen.getByRole('button', { name: 'Single' }));
       await fireEvent.input(screen.getByLabelText('Name'), { target: { value: 'Alice' } });
       await fireEvent.click(screen.getByRole('button', { name: 'Add' }));
 
@@ -574,7 +575,7 @@ describe('Participants', () => {
         expect(screen.getByText('Alice')).toBeInTheDocument();
       });
 
-      await fireEvent.click(screen.getByRole('button', { name: /Add Participant/i }));
+      await fireEvent.click(screen.getByRole('button', { name: 'Single' }));
       await fireEvent.input(screen.getByLabelText('Name'), { target: { value: 'aLiCe' } });
       await fireEvent.click(screen.getByRole('button', { name: 'Add' }));
 
@@ -588,10 +589,10 @@ describe('Participants', () => {
       render(Participants);
 
       await waitFor(() => {
-        expect(screen.getByRole('button', { name: /Add Participant/i })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Single' })).toBeInTheDocument();
       });
 
-      await fireEvent.click(screen.getByRole('button', { name: /Add Participant/i }));
+      await fireEvent.click(screen.getByRole('button', { name: 'Single' }));
       await fireEvent.input(screen.getByLabelText('Nights'), { target: { value: '0' } });
 
       expect(screen.getByText('Nights must be at least 1')).toBeInTheDocument();
@@ -604,10 +605,10 @@ describe('Participants', () => {
       render(Participants);
 
       await waitFor(() => {
-        expect(screen.getByRole('button', { name: /Add Participant/i })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Single' })).toBeInTheDocument();
       });
 
-      await fireEvent.click(screen.getByRole('button', { name: /Add Participant/i }));
+      await fireEvent.click(screen.getByRole('button', { name: 'Single' }));
       await fireEvent.input(screen.getByLabelText('Nights'), { target: { value: '400' } });
 
       expect(screen.getByText('Nights cannot exceed 365')).toBeInTheDocument();
@@ -620,10 +621,10 @@ describe('Participants', () => {
       render(Participants);
 
       await waitFor(() => {
-        expect(screen.getByRole('button', { name: /Add Participant/i })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Single' })).toBeInTheDocument();
       });
 
-      await fireEvent.click(screen.getByRole('button', { name: /Add Participant/i }));
+      await fireEvent.click(screen.getByRole('button', { name: 'Single' }));
 
       await fireEvent.input(screen.getByLabelText('Name'), { target: { value: 'Alice' } });
       await fireEvent.input(screen.getByLabelText('Nights'), { target: { value: '0' } });
@@ -641,10 +642,10 @@ describe('Participants', () => {
       render(Participants);
 
       await waitFor(() => {
-        expect(screen.getByRole('button', { name: /Add Participant/i })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Single' })).toBeInTheDocument();
       });
 
-      await fireEvent.click(screen.getByRole('button', { name: /Add Participant/i }));
+      await fireEvent.click(screen.getByRole('button', { name: 'Single' }));
 
       await fireEvent.input(screen.getByLabelText('Name'), { target: { value: 'Alice' } });
       await fireEvent.input(screen.getByLabelText('Nights'), { target: { value: '366' } });
@@ -674,10 +675,10 @@ describe('Participants', () => {
       render(Participants);
 
       await waitFor(() => {
-        expect(screen.getByRole('button', { name: /Add Participant/i })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Single' })).toBeInTheDocument();
       });
 
-      await fireEvent.click(screen.getByRole('button', { name: /Add Participant/i }));
+      await fireEvent.click(screen.getByRole('button', { name: 'Single' }));
 
       await fireEvent.input(screen.getByLabelText('Name'), { target: { value: 'Alice' } });
       await fireEvent.input(screen.getByLabelText('Nights'), { target: { value: '2' } });
@@ -713,10 +714,10 @@ describe('Participants', () => {
       render(Participants);
 
       await waitFor(() => {
-        expect(screen.getByRole('button', { name: /Add Participant/i })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Single' })).toBeInTheDocument();
       });
 
-      await fireEvent.click(screen.getByRole('button', { name: /Add Participant/i }));
+      await fireEvent.click(screen.getByRole('button', { name: 'Single' }));
       await fireEvent.input(screen.getByLabelText('Name'), { target: { value: 'Alice' } });
       await fireEvent.click(screen.getByRole('button', { name: 'Add' }));
 
@@ -737,10 +738,10 @@ describe('Participants', () => {
       render(Participants);
 
       await waitFor(() => {
-        expect(screen.getByRole('button', { name: /Add Participant/i })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Single' })).toBeInTheDocument();
       });
 
-      await fireEvent.click(screen.getByRole('button', { name: /Add Participant/i }));
+      await fireEvent.click(screen.getByRole('button', { name: 'Single' }));
       expect(screen.getByLabelText('Name')).toBeInTheDocument();
 
       await fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
@@ -748,7 +749,8 @@ describe('Participants', () => {
       await waitFor(() => {
         expect(screen.queryByLabelText('Name')).not.toBeInTheDocument();
       });
-      expect(screen.getByRole('button', { name: /Add Participant/i })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Single' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Family' })).toBeInTheDocument();
     });
   });
 
@@ -913,33 +915,33 @@ describe('Participants', () => {
     });
   });
 
-  // --- Number of Persons ---
+  // --- Share / Members ---
 
-  describe('Number of Persons', () => {
-    it('shows Persons input field in add form', async () => {
+  describe('Share field (single mode)', () => {
+    it('shows Share input field in single add form', async () => {
       vi.mocked(getSplit).mockResolvedValue(mockSplitEmpty);
 
       render(Participants);
 
       await waitFor(() => {
-        expect(screen.getByRole('button', { name: /Add Participant/i })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Single' })).toBeInTheDocument();
       });
 
-      await fireEvent.click(screen.getByRole('button', { name: /Add Participant/i }));
+      await fireEvent.click(screen.getByRole('button', { name: 'Single' }));
 
       expect(screen.getByLabelText('Share')).toBeInTheDocument();
     });
 
-    it('defaults Persons to 1 in add form', async () => {
+    it('defaults Share to 1 in single add form', async () => {
       vi.mocked(getSplit).mockResolvedValue(mockSplitEmpty);
 
       render(Participants);
 
       await waitFor(() => {
-        expect(screen.getByRole('button', { name: /Add Participant/i })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Single' })).toBeInTheDocument();
       });
 
-      await fireEvent.click(screen.getByRole('button', { name: /Add Participant/i }));
+      await fireEvent.click(screen.getByRole('button', { name: 'Single' }));
 
       const personsInput = screen.getByLabelText('Share') as HTMLInputElement;
       expect(personsInput.value).toBe('1');
@@ -965,10 +967,10 @@ describe('Participants', () => {
       render(Participants);
 
       await waitFor(() => {
-        expect(screen.getByRole('button', { name: /Add Participant/i })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Single' })).toBeInTheDocument();
       });
 
-      await fireEvent.click(screen.getByRole('button', { name: /Add Participant/i }));
+      await fireEvent.click(screen.getByRole('button', { name: 'Single' }));
 
       await fireEvent.input(screen.getByLabelText('Name'), { target: { value: 'Alice' } });
       await fireEvent.input(screen.getByLabelText('Nights'), { target: { value: '2' } });
@@ -1031,10 +1033,10 @@ describe('Participants', () => {
       render(Participants);
 
       await waitFor(() => {
-        expect(screen.getByRole('button', { name: /Add Participant/i })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Single' })).toBeInTheDocument();
       });
 
-      await fireEvent.click(screen.getByRole('button', { name: /Add Participant/i }));
+      await fireEvent.click(screen.getByRole('button', { name: 'Single' }));
       await fireEvent.input(screen.getByLabelText('Share'), { target: { value: '0' } });
 
       expect(screen.getByText('Must be at least 0.5')).toBeInTheDocument();
@@ -1046,12 +1048,107 @@ describe('Participants', () => {
       render(Participants);
 
       await waitFor(() => {
-        expect(screen.getByRole('button', { name: /Add Participant/i })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Single' })).toBeInTheDocument();
       });
 
-      await fireEvent.click(screen.getByRole('button', { name: /Add Participant/i }));
+      await fireEvent.click(screen.getByRole('button', { name: 'Single' }));
       await fireEvent.input(screen.getByLabelText('Share'), { target: { value: '51' } });
 
+      expect(screen.getByText('Cannot exceed 50')).toBeInTheDocument();
+    });
+  });
+
+  // --- Add Family ---
+
+  describe('Add Family', () => {
+    it('shows Family button', async () => {
+      vi.mocked(getSplit).mockResolvedValue(mockSplitEmpty);
+      render(Participants);
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: 'Family' })).toBeInTheDocument();
+      });
+    });
+
+    it('shows Members field (not Share) when Family button is clicked', async () => {
+      vi.mocked(getSplit).mockResolvedValue(mockSplitEmpty);
+      render(Participants);
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: 'Family' })).toBeInTheDocument();
+      });
+      await fireEvent.click(screen.getByRole('button', { name: 'Family' }));
+      expect(screen.getByLabelText('Members')).toBeInTheDocument();
+      expect(screen.queryByLabelText('Share')).not.toBeInTheDocument();
+    });
+
+    it('shows New Family title when Family button is clicked', async () => {
+      vi.mocked(getSplit).mockResolvedValue(mockSplitEmpty);
+      render(Participants);
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: 'Family' })).toBeInTheDocument();
+      });
+      await fireEvent.click(screen.getByRole('button', { name: 'Family' }));
+      expect(screen.getByText('New Family')).toBeInTheDocument();
+    });
+
+    it('defaults Members to 1 in family form', async () => {
+      vi.mocked(getSplit).mockResolvedValue(mockSplitEmpty);
+      render(Participants);
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: 'Family' })).toBeInTheDocument();
+      });
+      await fireEvent.click(screen.getByRole('button', { name: 'Family' }));
+      const membersInput = screen.getByLabelText('Members') as HTMLInputElement;
+      expect(membersInput.value).toBe('1');
+    });
+
+    it('submits family with members as share', async () => {
+      const mockSplitAfter: SplitType = {
+        ...mockSplitEmpty,
+        participants: [{ id: 'p1', name: 'Smith family', nights: 3, share: 2.5 }],
+      };
+      vi.mocked(getSplit)
+        .mockResolvedValueOnce(mockSplitEmpty)
+        .mockResolvedValueOnce(mockSplitAfter);
+      vi.mocked(addParticipant).mockResolvedValue({ id: 'p1', name: 'Smith family', nights: 3, share: 2.5 });
+
+      render(Participants);
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: 'Family' })).toBeInTheDocument();
+      });
+      await fireEvent.click(screen.getByRole('button', { name: 'Family' }));
+      await fireEvent.input(screen.getByLabelText('Name'), { target: { value: 'Smith family' } });
+      await fireEvent.input(screen.getByLabelText('Nights'), { target: { value: '3' } });
+      await fireEvent.input(screen.getByLabelText('Members'), { target: { value: '2.5' } });
+      await fireEvent.click(screen.getByRole('button', { name: 'Add' }));
+
+      await waitFor(() => {
+        expect(addParticipant).toHaveBeenCalledWith('test-split-id', {
+          name: 'Smith family',
+          nights: 3,
+          share: 2.5,
+        });
+      });
+    });
+
+    it('shows Members validation error when too low', async () => {
+      vi.mocked(getSplit).mockResolvedValue(mockSplitEmpty);
+      render(Participants);
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: 'Family' })).toBeInTheDocument();
+      });
+      await fireEvent.click(screen.getByRole('button', { name: 'Family' }));
+      await fireEvent.input(screen.getByLabelText('Members'), { target: { value: '0' } });
+      expect(screen.getByText('Must be at least 0.5')).toBeInTheDocument();
+    });
+
+    it('shows Members validation error when too high', async () => {
+      vi.mocked(getSplit).mockResolvedValue(mockSplitEmpty);
+      render(Participants);
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: 'Family' })).toBeInTheDocument();
+      });
+      await fireEvent.click(screen.getByRole('button', { name: 'Family' }));
+      await fireEvent.input(screen.getByLabelText('Members'), { target: { value: '51' } });
       expect(screen.getByText('Cannot exceed 50')).toBeInTheDocument();
     });
   });
@@ -1158,29 +1255,4 @@ describe('Participants', () => {
     });
   });
 
-  describe('Auto-open from Home creation flow', () => {
-    it('auto-opens add form when addParticipant search param is present', async () => {
-      vi.mocked(getSplit).mockResolvedValue(mockSplitEmpty);
-      (route as any).search = { addParticipant: 'true' };
-
-      render(Participants);
-
-      await waitFor(() => {
-        expect(screen.getByText('New Participant')).toBeInTheDocument();
-      });
-    });
-
-    it('does not auto-open add form when addParticipant search param is absent', async () => {
-      vi.mocked(getSplit).mockResolvedValue(mockSplitEmpty);
-      (route as any).search = {};
-
-      render(Participants);
-
-      await waitFor(() => {
-        expect(screen.getByRole('button', { name: /Add Participant/i })).toBeInTheDocument();
-      });
-
-      expect(screen.queryByText('New Participant')).not.toBeInTheDocument();
-    });
-  });
 });

--- a/src/main/doc/implementation/2026-04-04-Feature-participant-add-ux.md
+++ b/src/main/doc/implementation/2026-04-04-Feature-participant-add-ux.md
@@ -1,0 +1,61 @@
+# Feature: Participant Addition UX Improvement
+
+## What, Why and Constraints
+
+**What:** Improved the participant addition flow on the Participants page (issue #88):
+
+1. **Removed auto-open on split creation** — `Home.svelte` no longer passes `search: { addParticipant: 'true' }` when navigating to participants, and `Participants.svelte` no longer has a `$effect` that auto-opens the add form on arrival.
+2. **Two add buttons** — replaced the single "Add Participant" button with "Single" and "Family" buttons, each opening a tailored form.
+3. **Add Single form** — unchanged: name, nights, share (same as before).
+4. **Add Family form** — same name and nights fields, but the share field is relabeled "Members" (step 0.5, min 0.5) with a detailed help text: children count for 0.5, concrete example (2 adults + 2 children = 3 members), and a note that a parent leaving early should be added as a separate single participant. Both forms call the same `addParticipant` API.
+
+**Why:** Issue #88 — adding participants was not user-friendly. The auto-open on creation was surprising. There was no easy way to add a family group with an intuitive "members" label; users had to understand the "share" concept themselves.
+
+**Constraints:**
+- The backend API is unchanged — `addParticipant` accepts the same payload. "Members" is stored as `share`.
+- `addMode: 'single' | 'family' | null` replaces the boolean `showAddForm`, driving both button visibility and form variant.
+- `formMembers` (family) and `formShare` (single) are separate state fields to avoid contamination between modes.
+
+## How
+
+### Files modified
+
+**`Home.svelte`**
+- Removed `search: { addParticipant: 'true' }` from the `navigate()` call after split creation
+
+**`Participants.svelte`**
+- Removed `$effect` that auto-opened the add form when `route.search?.addParticipant` was set
+- Replaced `showAddForm: boolean` with `addMode: 'single' | 'family' | null`
+- Added `formMembers = $state(1)` for family mode
+- Extended `validationErrors` type to include `members`
+- Added `members` entry to `fieldInfo` with help text (children = 0.5)
+- Extended `activeFieldInfo` type to `'nights' | 'share' | 'members' | null`
+- Split `handleShowAddForm` into `handleShowSingleForm` and `handleShowFamilyForm`
+- Updated `handleCancelAddForm` to reset `addMode = null` and `formMembers`
+- Added `validateMembersOnInput` validation function
+- Updated `validateAddForm` to validate `formMembers` in family mode, `formShare` in single mode
+- Updated `handleAddParticipant` to use `formMembers` as share in family mode
+- Updated template: two buttons ("Single" with `Plus` icon, "Family" with `Users` icon) → form shows "New Participant" or "New Family" title; Members field replaces Share field in family mode
+
+### Files modified (tests)
+
+**`Home.test.ts`**
+- Removed `search: { addParticipant: 'true' }` from the navigation assertion after split creation
+
+**`Participants.test.ts`**
+- Removed `Auto-open from Home creation flow` describe (2 tests deleted)
+- Renamed "Add Participant" describe tests to use `'Single'` button
+- Updated button queries from `/Add Participant/i` → `'Single'`
+- Updated "shows Add Participant button" → "shows Single and Family buttons" (asserts both)
+- Updated "closes form" test to assert both `'Single'` and `'Family'` buttons after cancel
+- Renamed "Number of Persons" describe → "Share field (single mode)"
+- Added new "Add Family" describe with 7 tests: Family button visible, Members field shown (not Share), "New Family" title, Members default 1, API call submits members as share, Members validation (too low, too high)
+
+## Tests
+
+| File | Tests | Coverage |
+|---|---|---|
+| `Home.test.ts` | 18 (updated 1) | Navigation no longer passes addParticipant param |
+| `Participants.test.ts` | 62 (removed 2, updated ~20, added 7) | Single/Family buttons, family form fields, Members validation, API submission |
+
+**Total: 463 tests passing (full suite).**


### PR DESCRIPTION
## Summary
- Replaced single "Add Participant" button with **Single** and **Family** buttons
- Family form uses a **Members** field (step 0.5) instead of Share, with help text explaining children count for 0.5 and how to handle a parent leaving early
- Removed auto-open of add form when navigating from split creation

## Test plan
- [x] All 463 tests pass (`npx vitest run`)
- [x] Participants page shows "Single" and "Family" buttons when not settled
- [x] "Single" opens form with Name / Nights / Share fields
- [x] "Family" opens form with Name / Nights / Members fields and "New Family" title
- [x] Members info button shows example (2 adults + 2 children = 3) and early-departure note
- [x] Creating a new split navigates to participants page without auto-opening the form

🤖 Generated with [Claude Code](https://claude.com/claude-code)