### PR TITLE
fix: remove Share field from single participant form (#88)

### DIFF
--- a/fairnsquare-app/src/main/webui/src/routes/Participants.svelte
+++ b/fairnsquare-app/src/main/webui/src/routes/Participants.svelte
@@ -17,16 +17,12 @@
   import { Plus, Wallet, Receipt, TrendingUp, TrendingDown, Minus, Info, X, Users } from 'lucide-svelte';
 
   // Field info modal state (add form)
-  let activeFieldInfo = $state<'nights' | 'share' | 'members' | null>(null);
+  let activeFieldInfo = $state<'nights' | 'members' | null>(null);
 
   const fieldInfo = {
     nights: {
       title: 'Nights',
       description: `The number of nights this participant stays during the trip.\n\nUsed in the "By Night" split mode: costs are divided proportionally based on each participant's nights × share weight.\n\nExample: a participant staying 3 nights out of a 7-night trip pays for 3/7 of the night-based expenses (adjusted by their share).`,
-    },
-    share: {
-      title: 'Share',
-      description: `The number of persons this participant represents.\n\nA solo traveller has a share of 1. A couple sharing costs would have a share of 2, a family of 3 would use 3, etc.\n\nUsed in "By Night" mode (nights × share) and "By Share" mode (share only) to calculate each participant's proportional contribution.\n\nExample: a couple (share 2) staying 3 nights counts as 6 night-shares, compared to 3 night-shares for a solo person staying the same time.`,
     },
     members: {
       title: 'Members',
@@ -55,9 +51,8 @@
   let nameInputEl = $state<HTMLInputElement | null>(null);
   let formName = $state('');
   let formNights = $state(1);
-  let formShare = $state(1);
   let formMembers = $state(1);
-  let validationErrors = $state<{name?: string; nights?: string; share?: string; members?: string}>({});
+  let validationErrors = $state<{name?: string; nights?: string; members?: string}>({});
   let isSubmitting = $state(false);
 
   // Edit Participant state
@@ -173,7 +168,6 @@
     addMode = 'single';
     formName = '';
     formNights = loadNightsDefault();
-    formShare = 1;
     validationErrors = {};
     await tick();
     nameInputEl?.focus();
@@ -193,7 +187,6 @@
     addMode = null;
     formName = '';
     formNights = 1;
-    formShare = 1;
     formMembers = 1;
     validationErrors = {};
   }
@@ -222,16 +215,6 @@
     validationErrors = { ...validationErrors, nights: nightsError };
   }
 
-  function validateShareOnInput() {
-    let error: string | undefined;
-    if (formShare < 0.5) {
-      error = 'Must be at least 0.5';
-    } else if (formShare > 50) {
-      error = 'Cannot exceed 50';
-    }
-    validationErrors = { ...validationErrors, share: error };
-  }
-
   function validateMembersOnInput() {
     let error: string | undefined;
     if (formMembers < 0.5) {
@@ -243,7 +226,7 @@
   }
 
   function validateAddForm(): boolean {
-    const errors: {name?: string; nights?: string; share?: string; members?: string} = {};
+    const errors: {name?: string; nights?: string; members?: string} = {};
 
     if (!formName.trim()) {
       errors.name = 'Name is required';
@@ -265,12 +248,6 @@
       } else if (formMembers > 50) {
         errors.members = 'Cannot exceed 50';
       }
-    } else {
-      if (formShare < 0.5) {
-        errors.share = 'Must be at least 0.5';
-      } else if (formShare > 50) {
-        errors.share = 'Cannot exceed 50';
-      }
     }
 
     validationErrors = errors;
@@ -285,7 +262,7 @@
     try {
       const addedName = formName.trim();
       const addedNights = formNights;
-      const addedShare = addMode === 'family' ? formMembers : formShare;
+      const addedShare = addMode === 'family' ? formMembers : 1;
       await addParticipant(splitId, {
         name: addedName,
         nights: addedNights,
@@ -296,7 +273,6 @@
       addMode = null;
       formName = '';
       formNights = 1;
-      formShare = 1;
       formMembers = 1;
       validationErrors = {};
       await loadSplit(splitId);
@@ -520,29 +496,6 @@
                   />
                   {#if validationErrors.members}
                     <p class="text-sm text-destructive">{validationErrors.members}</p>
-                  {/if}
-                </div>
-              {:else}
-                <div class="space-y-2 flex-1">
-                  <div class="flex items-center gap-1">
-                    <Label for="participant-share">Share</Label>
-                    <button type="button" onclick={() => { activeFieldInfo = 'share'; }} class="p-0.5 rounded-full hover:bg-muted text-muted-foreground" aria-label="Info about Share">
-                      <Info class="h-3.5 w-3.5" />
-                    </button>
-                  </div>
-                  <Input
-                    id="participant-share"
-                    type="number"
-                    step="0.5"
-                    min="0.5"
-                    max="50"
-                    bind:value={formShare}
-                    oninput={validateShareOnInput}
-                    class="min-h-[44px]"
-                    disabled={isSubmitting}
-                  />
-                  {#if validationErrors.share}
-                    <p class="text-sm text-destructive">{validationErrors.share}</p>
                   {/if}
                 </div>
               {/if}

--- a/fairnsquare-app/src/main/webui/src/routes/Participants.test.ts
+++ b/fairnsquare-app/src/main/webui/src/routes/Participants.test.ts
@@ -917,8 +917,8 @@ describe('Participants', () => {
 
   // --- Share / Members ---
 
-  describe('Share field (single mode)', () => {
-    it('shows Share input field in single add form', async () => {
+  describe('Single form', () => {
+    it('does not show Share input field in single add form', async () => {
       vi.mocked(getSplit).mockResolvedValue(mockSplitEmpty);
 
       render(Participants);
@@ -929,28 +929,13 @@ describe('Participants', () => {
 
       await fireEvent.click(screen.getByRole('button', { name: 'Single' }));
 
-      expect(screen.getByLabelText('Share')).toBeInTheDocument();
+      expect(screen.queryByLabelText('Share')).not.toBeInTheDocument();
     });
 
-    it('defaults Share to 1 in single add form', async () => {
-      vi.mocked(getSplit).mockResolvedValue(mockSplitEmpty);
-
-      render(Participants);
-
-      await waitFor(() => {
-        expect(screen.getByRole('button', { name: 'Single' })).toBeInTheDocument();
-      });
-
-      await fireEvent.click(screen.getByRole('button', { name: 'Single' }));
-
-      const personsInput = screen.getByLabelText('Share') as HTMLInputElement;
-      expect(personsInput.value).toBe('1');
-    });
-
-    it('sends share in API call', async () => {
+    it('sends share=1 in API call for single participant', async () => {
       const mockSplitWithParticipant: SplitType = {
         ...mockSplitEmpty,
-        participants: [{ id: 'p1', name: 'Alice', nights: 2, share: 2 }],
+        participants: [{ id: 'p1', name: 'Alice', nights: 2, share: 1 }],
       };
 
       vi.mocked(getSplit)
@@ -961,7 +946,7 @@ describe('Participants', () => {
         id: 'p1',
         name: 'Alice',
         nights: 2,
-        share: 2,
+        share: 1,
       });
 
       render(Participants);
@@ -974,14 +959,13 @@ describe('Participants', () => {
 
       await fireEvent.input(screen.getByLabelText('Name'), { target: { value: 'Alice' } });
       await fireEvent.input(screen.getByLabelText('Nights'), { target: { value: '2' } });
-      await fireEvent.input(screen.getByLabelText('Share'), { target: { value: '2' } });
       await fireEvent.click(screen.getByRole('button', { name: 'Add' }));
 
       await waitFor(() => {
         expect(addParticipant).toHaveBeenCalledWith('test-split-id', {
           name: 'Alice',
           nights: 2,
-          share: 2,
+          share: 1,
         });
       });
     });
@@ -1027,35 +1011,6 @@ describe('Participants', () => {
       });
     });
 
-    it('shows share too low error while typing', async () => {
-      vi.mocked(getSplit).mockResolvedValue(mockSplitEmpty);
-
-      render(Participants);
-
-      await waitFor(() => {
-        expect(screen.getByRole('button', { name: 'Single' })).toBeInTheDocument();
-      });
-
-      await fireEvent.click(screen.getByRole('button', { name: 'Single' }));
-      await fireEvent.input(screen.getByLabelText('Share'), { target: { value: '0' } });
-
-      expect(screen.getByText('Must be at least 0.5')).toBeInTheDocument();
-    });
-
-    it('shows share too high error while typing', async () => {
-      vi.mocked(getSplit).mockResolvedValue(mockSplitEmpty);
-
-      render(Participants);
-
-      await waitFor(() => {
-        expect(screen.getByRole('button', { name: 'Single' })).toBeInTheDocument();
-      });
-
-      await fireEvent.click(screen.getByRole('button', { name: 'Single' }));
-      await fireEvent.input(screen.getByLabelText('Share'), { target: { value: '51' } });
-
-      expect(screen.getByText('Cannot exceed 50')).toBeInTheDocument();
-    });
   });
 
   // --- Add Family ---

--- a/src/main/doc/implementation/2026-04-04-Bugfix-88-remove-share-from-single.md
+++ b/src/main/doc/implementation/2026-04-04-Bugfix-88-remove-share-from-single.md
@@ -1,0 +1,44 @@
+# Bugfix: Remove Share Field from Single Participant Form (#88 follow-up)
+
+## What, Why and Constraints
+
+**What:** Removed the Share input field from the "Single" participant add form. Single participants now always submit `share: 1` implicitly. The Share/Members concept is only exposed in the "Family" form.
+
+**Why:** Issue #88 comment — "The change is ok, but I would remove the shares from single participant." A solo traveller always represents 1 person; the Share concept is only meaningful for family groups with children (0.5 per child). Exposing Share in the Single form added unnecessary complexity for the common case.
+
+**Constraints:**
+- The backend API is unchanged — `addParticipant` still accepts `share`. Single mode simply always sends `share: 1`.
+- The Family form retains the Members field (min 0.5, step 0.5) with its help text.
+
+## How
+
+### Files modified
+
+**`Participants.svelte`**
+- Removed `let formShare = $state(1)` (state field)
+- Removed `activeFieldInfo` type variant `'share'`
+- Removed `fieldInfo.share` entry
+- Removed `validationErrors` type field `share`
+- Removed `validateShareOnInput()` function
+- Removed `else` branch (share validation for single mode) from `validateAddForm()`
+- Changed `addMode === 'family' ? formMembers : formShare` → `addMode === 'family' ? formMembers : 1` in `handleAddParticipant`
+- Removed `formShare = 1` reset in `handleAddParticipant`
+- Removed the `{:else}` Share field block from the Nights/Share/Members row in the template
+
+### Files modified (tests)
+
+**`Participants.test.ts`**
+- Renamed "Share field (single mode)" describe → "Single form"
+- Removed test "shows Share input field in single add form"
+- Removed test "defaults Share to 1 in single add form"
+- Updated test "sends share in API call" → "sends share=1 in API call for single participant": removed Share field interaction, asserts `share: 1` without filling the field
+- Removed test "shows share too low error while typing"
+- Removed test "shows share too high error while typing"
+
+## Tests
+
+| File | Tests | Coverage |
+|---|---|---|
+| `Participants.test.ts` | 460 passing (removed 4, updated 1) | Share field absent in single form, API call submits share=1 |
+
+**Total: 460 tests passing (full suite).**


### PR DESCRIPTION
## Summary

- Removed the Share input field from the Single participant add form
- Single participants now always submit `share: 1` implicitly
- Share/Members concept is only exposed in the Family form, where it makes sense (children = 0.5)

## Test plan

- [x] Click "Single" button — form shows Name and Nights only, no Share field
- [x] Add a single participant — API receives `share: 1`
- [x] Click "Family" button — Members field still present with info button
- [x] 460 tests passing

Closes #88 (follow-up to #105)

🤖 Generated with [Claude Code](https://claude.com/claude-code)