### PR TITLE
fix: hide expenses with zero spent and owned in participant modal

### DIFF
--- a/fairnsquare-app/src/main/webui/src/lib/components/participant/ParticipantExpensesModal.svelte
+++ b/fairnsquare-app/src/main/webui/src/lib/components/participant/ParticipantExpensesModal.svelte
@@ -22,7 +22,7 @@
     expenses.filter(
       (e) =>
         e.payerId === participant.id ||
-        e.shares.some((s) => s.participantId === participant.id)
+        e.shares.some((s) => s.participantId === participant.id && s.amount > 0)
     )
   );
 

--- a/fairnsquare-app/src/main/webui/src/lib/components/participant/ParticipantExpensesModal.test.ts
+++ b/fairnsquare-app/src/main/webui/src/lib/components/participant/ParticipantExpensesModal.test.ts
@@ -47,6 +47,20 @@ describe('ParticipantExpensesModal', () => {
     shares: [{ participantId: 'p-bob', amount: 50 }],
   };
 
+  // Bob paid €80, Alice has a zero-amount share (e.g. BY_NIGHT with 0 nights)
+  const expenseAliceZeroShare: Expense = {
+    id: 'e-4',
+    description: 'Zero share expense',
+    amount: 80,
+    payerId: 'p-bob',
+    splitMode: 'BY_NIGHT',
+    createdAt: '2026-01-04T00:00:00Z',
+    shares: [
+      { participantId: 'p-alice', amount: 0 },
+      { participantId: 'p-bob', amount: 80 },
+    ],
+  };
+
   const defaultProps = {
     open: true,
     participant: alice,
@@ -93,6 +107,14 @@ describe('ParticipantExpensesModal', () => {
         props: { ...defaultProps, expenses: [expenseAliceNotInvolved] },
       });
       expect(screen.getByText(/no expenses found/i)).toBeInTheDocument();
+    });
+
+    it('hides expenses where participant has a zero-amount share and is not payer', () => {
+      render(ParticipantExpensesModal, {
+        props: { ...defaultProps, expenses: [expenseAlicePaid, expenseAliceZeroShare] },
+      });
+      expect(screen.getByText('Groceries')).toBeInTheDocument();
+      expect(screen.queryByText('Zero share expense')).not.toBeInTheDocument();
     });
   });
 

--- a/src/main/doc/implementation/2026-04-08-Bugfix-filter-participant-zero-expenses.md
+++ b/src/main/doc/implementation/2026-04-08-Bugfix-filter-participant-zero-expenses.md
@@ -1,0 +1,31 @@
+# Bugfix: Filter Participant Zero-Amount Expenses
+
+## What, Why and Constraints
+
+**What:** In the participant expenses modal, expenses where the participant has a share entry with `amount = 0` (and is not the payer) were incorrectly shown. Since the participant neither spent nor owed anything, these expenses added noise without value.
+
+**Why:** Issue #116 — the existing filter included any expense where the participant appeared in the `shares` array, regardless of the share amount. This caused false positives for split modes like `BY_NIGHT` or `BY_SHARE` where a participant with 0 nights/shares still receives a `shares` entry with `amount: 0`.
+
+**Constraints:** Change limited to the filter predicate only; no data model or API changes required.
+
+## How
+
+### Files modified
+
+- **`ParticipantExpensesModal.svelte`** — Added `&& s.amount > 0` to the shares filter condition inside the `$derived` block:
+  ```js
+  // Before
+  e.shares.some((s) => s.participantId === participant.id)
+  // After
+  e.shares.some((s) => s.participantId === participant.id && s.amount > 0)
+  ```
+  The payer condition is unchanged: if the participant paid, `spent > 0` is always true (expense amount is always positive).
+
+- **`ParticipantExpensesModal.test.ts`** — Added:
+  - `expenseAliceZeroShare` fixture: Bob paid €80, Alice has a share entry with `amount: 0` (simulating `BY_NIGHT` with 0 nights)
+  - Test: `hides expenses where participant has a zero-amount share and is not payer`
+
+## Tests
+
+- **Automated:** 1 new test added in `ParticipantExpensesModal.test.ts`, all 17 tests pass.
+- The new test directly exercises the fixed scenario: expense with a zero-amount share does not appear in the modal for that participant.


### PR DESCRIPTION
## Summary
- Fixes #116
- Expenses where a participant has a `0`-amount share entry (e.g. `BY_NIGHT` with 0 nights) and is not the payer were incorrectly shown in the participant expenses modal
- Added `&& s.amount > 0` guard to the shares filter predicate in `ParticipantExpensesModal.svelte`

## Test plan
- [x] New automated test: `hides expenses where participant has a zero-amount share and is not payer`
- [x] All 17 tests in `ParticipantExpensesModal.test.ts` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)