### PR TITLE
fix: ensure rounding remainder goes to a beneficiary in FREE expenses

### DIFF
--- a/fairnsquare-app/src/main/java/org/asymetrik/web/fairnsquare/split/domain/expenses/ExpenseFree.java
+++ b/fairnsquare-app/src/main/java/org/asymetrik/web/fairnsquare/split/domain/expenses/ExpenseFree.java
@@ -85,6 +85,16 @@ public final class ExpenseFree extends Expense {
             return Collections.emptyList();
         }
 
+        // Find the last participant with positive parts so the rounding remainder
+        // always goes to an actual beneficiary, never to a zero-parts participant.
+        int lastPositiveIndex = -1;
+        for (int i = shares.size() - 1; i >= 0; i--) {
+            if (shares.get(i).parts().compareTo(BigDecimal.ZERO) > 0) {
+                lastPositiveIndex = i;
+                break;
+            }
+        }
+
         List<Share> calculatedShares = new ArrayList<>();
         BigDecimal totalAssigned = BigDecimal.ZERO;
 
@@ -92,8 +102,11 @@ public final class ExpenseFree extends Expense {
             Share partShare = shares.get(i);
             BigDecimal amount;
 
-            if (i == shares.size() - 1) {
-                // Last participant gets remainder to ensure sum equals expense amount
+            if (partShare.parts().compareTo(BigDecimal.ZERO) == 0) {
+                // Non-beneficiary: always zero, never absorbs rounding remainder
+                amount = BigDecimal.ZERO;
+            } else if (i == lastPositiveIndex) {
+                // Last beneficiary absorbs rounding remainder to ensure sum = expense amount
                 amount = getAmount().subtract(totalAssigned);
             } else {
                 // Calculate: amount = expenseTotal × (parts / totalParts)

--- a/fairnsquare-app/src/test/java/org/asymetrik/web/fairnsquare/split/domain/expenses/ExpenseFreeTest.java
+++ b/fairnsquare-app/src/test/java/org/asymetrik/web/fairnsquare/split/domain/expenses/ExpenseFreeTest.java
@@ -119,6 +119,49 @@ class ExpenseFreeTest {
     }
 
     @Test
+    void getShares_zeroPartsParticipantLast_getsExactlyZeroNotRoundingRemainder() {
+        // Regression test for #118: with HALF_UP rounding, Alice and Bob each round up to 0.51,
+        // leaving a remainder of -0.01 that must NOT go to Charlie (parts=0).
+        // Charlie must always get exactly 0; Bob (last positive) absorbs the remainder.
+        List<Expense.Share> shares = List.of(Expense.Share.withParts(ALICE_ID, new BigDecimal("1")),
+                Expense.Share.withParts(BOB_ID, new BigDecimal("1")),
+                Expense.Share.withParts(CHARLIE_ID, BigDecimal.ZERO));
+        ExpenseFree expense = ExpenseFree.create(new BigDecimal("1.01"), "Dinner", ALICE_ID, shares);
+
+        List<Expense.Share> result = expense.getShares(null);
+
+        assertThat(result).hasSize(3);
+        assertThat(result.get(0).participantId()).isEqualTo(ALICE_ID);
+        assertThat(result.get(0).amount()).isEqualByComparingTo("0.51");
+        assertThat(result.get(1).participantId()).isEqualTo(BOB_ID);
+        assertThat(result.get(1).amount()).isEqualByComparingTo("0.50"); // absorbs remainder
+        assertThat(result.get(2).participantId()).isEqualTo(CHARLIE_ID);
+        assertThat(result.get(2).amount()).isEqualByComparingTo("0.00"); // never negative
+
+        BigDecimal total = result.stream().map(Expense.Share::amount).reduce(BigDecimal.ZERO, BigDecimal::add);
+        assertThat(total).isEqualByComparingTo("1.01");
+    }
+
+    @Test
+    void getShares_zeroPartsParticipantInMiddle_getsExactlyZero() {
+        // Zero-parts participant in the middle (not last) must also get exactly 0
+        List<Expense.Share> shares = List.of(Expense.Share.withParts(ALICE_ID, new BigDecimal("2")),
+                Expense.Share.withParts(CHARLIE_ID, BigDecimal.ZERO),
+                Expense.Share.withParts(BOB_ID, new BigDecimal("1")));
+        ExpenseFree expense = ExpenseFree.create(new BigDecimal("100.00"), "Groceries", ALICE_ID, shares);
+
+        List<Expense.Share> result = expense.getShares(null);
+
+        assertThat(result).hasSize(3);
+        assertThat(result.get(0).amount()).isEqualByComparingTo("66.67"); // Alice: 2/3
+        assertThat(result.get(1).amount()).isEqualByComparingTo("0.00"); // Charlie: 0 parts
+        assertThat(result.get(2).amount()).isEqualByComparingTo("33.33"); // Bob: remainder
+
+        BigDecimal total = result.stream().map(Expense.Share::amount).reduce(BigDecimal.ZERO, BigDecimal::add);
+        assertThat(total).isEqualByComparingTo("100.00");
+    }
+
+    @Test
     void create_nullAmount_throwsException() {
         // Arrange
         List<Expense.Share> shares = List.of(Expense.Share.withParts(ALICE_ID, new BigDecimal("50.00")));

--- a/src/main/doc/implementation/2026-04-08-Bugfix-rounding-remainder-to-beneficiary.md
+++ b/src/main/doc/implementation/2026-04-08-Bugfix-rounding-remainder-to-beneficiary.md
@@ -1,0 +1,30 @@
+# Bugfix: Rounding Remainder Always Goes to a Beneficiary
+
+## What, Why and Constraints
+
+**What:** In `ExpenseFree` expenses, a participant with `parts=0` (a non-beneficiary) could end up owing a small negative or positive amount due to rounding when they happened to be the last entry in the shares list.
+
+**Why:** Issue #118 — the "last participant absorbs the remainder" pattern ensures `sum(shares) == expense.amount` exactly. But the loop previously used positional last (`i == shares.size() - 1`), not "last with positive parts". When HALF_UP rounding caused all preceding non-zero participants to round up, the final balance (e.g. -€0.01) landed on a zero-parts participant, making them incorrectly owe money.
+
+**Constraints:** Fix is confined to `ExpenseFree.getShares()`. `ExpenseByNight` and `ExpenseByShare` are not affected — their participant weights derive from `Participant.Nights` (min 0.5) and `Participant.Share` (min 0.5), so weight is always > 0 and all participants are always beneficiaries.
+
+## How
+
+### Files modified
+
+- **`ExpenseFree.java`** — Added a reverse scan before the main loop to find `lastPositiveIndex` (the last index with `parts > 0`). In the main loop:
+  - `parts == 0` → always assigns `BigDecimal.ZERO`
+  - `i == lastPositiveIndex` → absorbs the rounding remainder (`amount - totalAssigned`)
+  - Otherwise → standard proportional calculation
+
+  Original (bug): `if (i == shares.size() - 1)` — blindly gave remainder to last list entry.
+  Fixed: remainder goes to last entry with `parts > 0`.
+
+- **`ExpenseFreeTest.java`** — Added two regression tests:
+  - `getShares_zeroPartsParticipantLast_getsExactlyZeroNotRoundingRemainder`: €1.01 / [Alice(1), Bob(1), Charlie(0)] — Charlie must get €0.00, not -€0.01
+  - `getShares_zeroPartsParticipantInMiddle_getsExactlyZero`: €100 / [Alice(2), Charlie(0), Bob(1)] — Charlie in middle also gets €0.00, Bob (last positive) gets the remainder
+
+## Tests
+
+- **Automated:** 2 new tests added in `ExpenseFreeTest.java`, all 35 domain expense tests pass.
+- The first test directly reproduces the bug: without the fix, Charlie would receive -€0.01.


### PR DESCRIPTION
## Summary
- Fixes #118
- In `ExpenseFree` expenses, a participant with `parts=0` could incorrectly receive a negative rounding adjustment when they were last in the shares list and preceding participants had all rounded up (HALF_UP)
- Pre-scan now finds `lastPositiveIndex`; zero-parts participants always get `BigDecimal.ZERO`; the rounding remainder only goes to the last actual beneficiary

## Test plan
- [x] New test: `getShares_zeroPartsParticipantLast_getsExactlyZeroNotRoundingRemainder` — reproduces the exact bug (€1.01 / [Alice(1), Bob(1), Charlie(0)] → Charlie gets €0.00, not -€0.01)
- [x] New test: `getShares_zeroPartsParticipantInMiddle_getsExactlyZero` — zero-parts in middle also gets exactly €0.00
- [x] All 35 domain expense tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)