### PR TITLE
feat: improve expense view - rename By Share and show participant amounts (#114)

### DIFF
--- a/fairnsquare-app/src/main/webui/src/lib/components/expense/AddExpenseModal.test.ts
+++ b/fairnsquare-app/src/main/webui/src/lib/components/expense/AddExpenseModal.test.ts
@@ -918,16 +918,16 @@ describe('ExpenseEditModal', () => {
   // --- BY_SHARE Split Mode ---
 
   describe('BY_SHARE Split Mode', () => {
-    it('renders By Share radio button option', () => {
+    it('renders By Participant members radio button option', () => {
       render(ExpenseEditModal, { props: defaultProps });
 
-      expect(screen.getByRole('radio', { name: /by share/i })).toBeInTheDocument();
+      expect(screen.getByRole('radio', { name: /by participant members/i })).toBeInTheDocument();
     });
 
-    it('allows selecting By Share split mode', async () => {
+    it('allows selecting By Participant members split mode', async () => {
       render(ExpenseEditModal, { props: defaultProps });
 
-      const byShareRadio = screen.getByRole('radio', { name: /by share/i });
+      const byShareRadio = screen.getByRole('radio', { name: /by participant members/i });
       await fireEvent.click(byShareRadio);
 
       expect(byShareRadio).toBeChecked();
@@ -946,7 +946,7 @@ describe('ExpenseEditModal', () => {
 
       render(ExpenseEditModal, { props: defaultProps });
 
-      const byShareRadio = screen.getByRole('radio', { name: /by share/i });
+      const byShareRadio = screen.getByRole('radio', { name: /by participant members/i });
       await fireEvent.click(byShareRadio);
 
       const amountInput = screen.getByLabelText(/amount/i);
@@ -962,10 +962,10 @@ describe('ExpenseEditModal', () => {
       });
     });
 
-    it('does not show FREE mode share inputs when By Share is selected', async () => {
+    it('does not show FREE mode share inputs when By Participant members is selected', async () => {
       render(ExpenseEditModal, { props: defaultProps });
 
-      const byShareRadio = screen.getByRole('radio', { name: /by share/i });
+      const byShareRadio = screen.getByRole('radio', { name: /by participant members/i });
       await fireEvent.click(byShareRadio);
 
       expect(screen.queryByText(/share parts/i)).not.toBeInTheDocument();

--- a/fairnsquare-app/src/main/webui/src/lib/components/expense/EditExpenseModal.test.ts
+++ b/fairnsquare-app/src/main/webui/src/lib/components/expense/EditExpenseModal.test.ts
@@ -624,24 +624,24 @@ describe('ExpenseEditModal', () => {
   // --- BY_SHARE Split Mode ---
 
   describe('BY_SHARE Split Mode', () => {
-    it('renders By Share radio button option', () => {
+    it('renders By Participant members radio button option', () => {
       render(ExpenseEditModal, { props: defaultProps });
 
-      expect(screen.getByRole('radio', { name: /by share/i })).toBeInTheDocument();
+      expect(screen.getByRole('radio', { name: /by participant members/i })).toBeInTheDocument();
     });
 
     it('pre-selects BY_SHARE when expense uses BY_SHARE', () => {
       const byShareExpense = { ...mockExpense, splitMode: 'BY_SHARE' as const };
       render(ExpenseEditModal, { props: { ...defaultProps, expense: byShareExpense } });
 
-      const byShareRadio = screen.getByRole('radio', { name: /by share/i });
+      const byShareRadio = screen.getByRole('radio', { name: /by participant members/i });
       expect(byShareRadio).toBeChecked();
     });
 
     it('enables Save Changes when split mode is changed to BY_SHARE', async () => {
       render(ExpenseEditModal, { props: defaultProps });
 
-      const byShareRadio = screen.getByRole('radio', { name: /by share/i });
+      const byShareRadio = screen.getByRole('radio', { name: /by participant members/i });
       await fireEvent.click(byShareRadio);
 
       const saveButton = screen.getByRole('button', { name: /save changes/i });
@@ -656,7 +656,7 @@ describe('ExpenseEditModal', () => {
 
       render(ExpenseEditModal, { props: defaultProps });
 
-      const byShareRadio = screen.getByRole('radio', { name: /by share/i });
+      const byShareRadio = screen.getByRole('radio', { name: /by participant members/i });
       await fireEvent.click(byShareRadio);
 
       const saveButton = screen.getByRole('button', { name: /save changes/i });

--- a/fairnsquare-app/src/main/webui/src/lib/components/expense/ExpenseEditModal.svelte
+++ b/fairnsquare-app/src/main/webui/src/lib/components/expense/ExpenseEditModal.svelte
@@ -68,8 +68,8 @@
       description: `The cost is divided equally among all participants, regardless of their nights, share weight, or any other factor.\n\nExample: 3 participants share a €90 expense → each pays €30.`,
     },
     BY_SHARE: {
-      title: 'By Share',
-      description: `The cost is split proportionally to each participant's share weight, which represents their number of persons.\n\nExample: Alice (1 share) and a couple Bob & Carol (2 shares) share a €90 expense. Total = 3 shares. Alice pays €30 (1/3), Bob & Carol pay €60 (2/3).`,
+      title: 'By Participant members',
+      description: `The cost is split proportionally to each participant's share weight, which represents their number of persons.\n\nThis is ideal for shared expenses where everyone was present, like a restaurant meal.\n\nExample: Alice (1 person) and a couple Bob & Carol (2 persons) share a €90 restaurant bill. Total = 3 shares. Alice pays €30 (1/3), Bob & Carol pay €60 (2/3).`,
     },
     FREE: {
       title: 'Manual',
@@ -582,9 +582,9 @@
               <RadioGroup.Item value="BY_SHARE" id="modal-mode-by-share" />
               <Label for="modal-mode-by-share" class="flex items-center gap-2 cursor-pointer flex-1">
                 <Users class="h-4 w-4" aria-hidden="true" />
-                <span>By Share</span>
+                <span>By Participant members</span>
               </Label>
-              <button type="button" onclick={(e) => openInfo('BY_SHARE', e)} class="p-1 rounded-full hover:bg-muted text-muted-foreground" aria-label="Info about By Share">
+              <button type="button" onclick={(e) => openInfo('BY_SHARE', e)} class="p-1 rounded-full hover:bg-muted text-muted-foreground" aria-label="Info about By Participant members">
                 <Info class="h-4 w-4" />
               </button>
             </div>

--- a/fairnsquare-app/src/main/webui/src/lib/components/ui/expense-card/ExpenseCard.svelte
+++ b/fairnsquare-app/src/main/webui/src/lib/components/ui/expense-card/ExpenseCard.svelte
@@ -26,11 +26,13 @@
   function formatSplitMode(mode: string): string {
     switch (mode) {
       case 'BY_NIGHT': return 'By Night';
+      case 'BY_SHARE': return 'By Members';
       case 'EQUAL': return 'Equal';
       case 'FREE': return 'Free';
       default: return mode;
     }
   }
+
 
   function getPayerName(): string {
     return split.participants.find(p => p.id === expense.payerId)?.name || 'Unknown';

--- a/fairnsquare-app/src/main/webui/src/routes/ExpenseList.svelte
+++ b/fairnsquare-app/src/main/webui/src/routes/ExpenseList.svelte
@@ -147,7 +147,7 @@
       case 'EQUAL':
         return 'Equal';
       case 'BY_SHARE':
-        return 'By Share';
+        return 'By Members';
       case 'FREE':
         return 'Manual';
     }
@@ -157,17 +157,15 @@
     return split?.participants.find((p) => p.id === payerId)?.name || 'Unknown';
   }
 
-  function getParticipantNames(expense: Expense): string {
+  function getParticipantSharesText(expense: Expense): string {
     if (!split) return '';
-    // For FREE mode, only show participants with positive parts
-    const activeShares = expense.splitMode === 'FREE'
-      ? expense.shares.filter((s) => s.parts != null && s.parts > 0)
-      : expense.shares;
-    const participantIds = activeShares.map((s) => s.participantId);
-    if (participantIds.length === split.participants.length) return 'Everyone';
-    return participantIds
-      .map((id) => split!.participants.find((p) => p.id === id)?.name || 'Unknown')
-      .join(', ');
+    const activeShares = expense.shares.filter((s) => s.amount > 0);
+    return activeShares
+      .map((s) => {
+        const name = split!.participants.find((p) => p.id === s.participantId)?.name || 'Unknown';
+        return `${name}: ${formatCurrency(s.amount)}`;
+      })
+      .join(' · ');
   }
 
   function updateFilterUrl(payer: string, beneficiary: string) {
@@ -418,14 +416,20 @@
                 <span class="text-xs text-muted-foreground">{formatDate(expense.createdAt)}</span>
               </div>
 
-              <!-- Row 3: Split Mode + Participants -->
-              <div class="flex items-center justify-between mb-2">
+              <!-- Row 3: Split Mode -->
+              <div class="flex items-center mb-1">
                 <span class="text-xs text-muted-foreground">
                   {splitModeIcon(expense.splitMode)}
                   {splitModeText(expense.splitMode)}
                 </span>
-                <span class="text-xs text-muted-foreground">{getParticipantNames(expense)}</span>
               </div>
+
+              <!-- Row 4: Participant amounts -->
+              {#if getParticipantSharesText(expense)}
+                <p class="text-xs text-muted-foreground mb-2 leading-relaxed">
+                  {getParticipantSharesText(expense)}
+                </p>
+              {/if}
 
               <!-- Row 4: Actions -->
               {#if !isSettled}

--- a/fairnsquare-app/src/main/webui/src/routes/ExpenseList.test.ts
+++ b/fairnsquare-app/src/main/webui/src/routes/ExpenseList.test.ts
@@ -288,13 +288,66 @@ describe('ExpenseList', () => {
       expect(screen.getByText(/Equal/)).toBeInTheDocument();
     });
 
-    it('shows participants as Everyone when all participate (AC 4)', async () => {
+    it('shows participant amounts on expense cards (AC 4)', async () => {
       vi.mocked(getSplit).mockResolvedValue(mockSplitWithExpenses);
       render(ExpenseList);
 
       await waitFor(() => {
-        const everyoneLabels = screen.getAllByText('Everyone');
-        expect(everyoneLabels.length).toBeGreaterThanOrEqual(1);
+        // Groceries: Alice €60, Bob €30
+        expect(screen.getByText('Alice: €60.00 · Bob: €30.00')).toBeInTheDocument();
+        // Dinner: Alice €30, Bob €30
+        expect(screen.getByText('Alice: €30.00 · Bob: €30.00')).toBeInTheDocument();
+      });
+    });
+
+    it('filters out zero-amount participants from card display', async () => {
+      const splitWithZeroShare: SplitType = {
+        ...mockSplitWithExpenses,
+        expenses: [{
+          id: 'e3',
+          description: 'Free Split',
+          amount: 100.0,
+          payerId: 'p1',
+          splitMode: 'FREE' as const,
+          createdAt: '2026-01-27T10:00:00Z',
+          shares: [
+            { participantId: 'p1', amount: 100.0, parts: 1 },
+            { participantId: 'p2', amount: 0.0, parts: 0 },
+          ],
+        }],
+      };
+      vi.mocked(getSplit).mockResolvedValue(splitWithZeroShare);
+      render(ExpenseList);
+
+      await waitFor(() => {
+        expect(screen.getByText('Free Split')).toBeInTheDocument();
+      });
+      // Only Alice should appear in participant amounts (Bob has €0)
+      expect(screen.getByText('Alice: €100.00')).toBeInTheDocument();
+      expect(screen.queryByText(/Bob:/)).not.toBeInTheDocument();
+    });
+
+    it('shows By Members badge for BY_SHARE expenses', async () => {
+      const splitWithByShare: SplitType = {
+        ...mockSplitWithExpenses,
+        expenses: [{
+          id: 'e3',
+          description: 'Restaurant',
+          amount: 90.0,
+          payerId: 'p1',
+          splitMode: 'BY_SHARE' as const,
+          createdAt: '2026-01-27T10:00:00Z',
+          shares: [
+            { participantId: 'p1', amount: 30.0 },
+            { participantId: 'p2', amount: 60.0 },
+          ],
+        }],
+      };
+      vi.mocked(getSplit).mockResolvedValue(splitWithByShare);
+      render(ExpenseList);
+
+      await waitFor(() => {
+        expect(screen.getByText(/By Members/)).toBeInTheDocument();
       });
     });
 

--- a/src/main/doc/implementation/2026-04-09-Feature-improve-expense-create-update-view.md
+++ b/src/main/doc/implementation/2026-04-09-Feature-improve-expense-create-update-view.md
@@ -1,0 +1,63 @@
+# Feature: Improve Expense Create/Update View (#114)
+
+## What, Why and Constraints
+
+**What:** Two UI improvements to the expense experience:
+1. Renamed the "By Share" split mode to "By Participant members" (label, aria-label, and info modal title/description) in the expense create/update modal.
+2. Added an always-visible participant amounts list on each expense card — showing each participant's owned amount (non-zero only), wrapping across lines when there are many participants.
+
+**Why:** The label "By Share" was ambiguous. "By Participant members" better communicates that the cost is split based on how many people each participant represents (share weight). The participant amounts on the expense card give at-a-glance visibility into who owes what, without requiring any interaction.
+
+**Constraints:**
+- Frontend rules followed: responsive layout verified on mobile (390×844) and desktop (1280×800).
+- No backend changes required — all data was already available via `expense.shares[].amount`.
+- `ExpenseCard.svelte` exists as a component but is not used in the UI (only in tests); the actual expense cards are rendered inline in `ExpenseList.svelte`. Changes were applied to the correct file.
+
+---
+
+## How
+
+### Files Modified
+
+**`fairnsquare-app/src/main/webui/src/lib/components/expense/ExpenseEditModal.svelte`**
+- Changed `<span>By Share</span>` → `<span>By Participant members</span>` in the radio group.
+- Updated `aria-label="Info about By Share"` → `aria-label="Info about By Participant members"`.
+- Updated `splitModeInfo.BY_SHARE.title` → `"By Participant members"`.
+- Updated `splitModeInfo.BY_SHARE.description` to include a restaurant example: *"This is ideal for shared expenses where everyone was present, like a restaurant meal."*
+
+**`fairnsquare-app/src/main/webui/src/lib/components/ui/expense-card/ExpenseCard.svelte`**
+- Added `BY_SHARE` case to `formatSplitMode()` → returns `"By Members"` (component exists but is not rendered in the UI; fixed for correctness).
+
+**`fairnsquare-app/src/main/webui/src/routes/ExpenseList.svelte`**
+- Updated `splitModeText()` for `BY_SHARE` → `"By Members"`.
+- Replaced `getParticipantNames()` (which returned names only, or "Everyone") with `getParticipantSharesText()` which returns `"Alice: €30.00 · Bob: €45.00"` format, filtered to shares with `amount > 0`.
+- Added a new Row 4 in the expense card template to render the participant amounts paragraph, with `leading-relaxed` allowing natural line-wrapping for expenses with many participants.
+
+**`fairnsquare-app/src/main/webui/src/lib/components/expense/EditExpenseModal.test.ts`**
+- Updated all `{ name: /by share/i }` role queries → `{ name: /by participant members/i }`.
+- Updated test description strings accordingly.
+
+**`fairnsquare-app/src/main/webui/src/lib/components/expense/AddExpenseModal.test.ts`**
+- Same updates as `EditExpenseModal.test.ts`.
+
+**`fairnsquare-app/src/main/webui/src/routes/ExpenseList.test.ts`**
+- Replaced `'shows participants as Everyone when all participate'` test with `'shows participant amounts on expense cards'`, asserting the new `"Alice: €60.00 · Bob: €30.00"` format.
+- Added `'filters out zero-amount participants from card display'` — verifies that a participant with `amount: 0` does not appear in the shares text.
+- Added `'shows By Members badge for BY_SHARE expenses'` — verifies the badge text for BY_SHARE mode.
+
+---
+
+## Tests
+
+All automated tests pass:
+
+| File | Tests |
+|---|---|
+| `EditExpenseModal.test.ts` | Updated 4 assertions for "By Participant members" label |
+| `AddExpenseModal.test.ts` | Updated 4 assertions + test descriptions |
+| `ExpenseList.test.ts` | Replaced 1 test, added 2 new tests |
+| **Total** | **150 tests passing** |
+
+Visual verification performed with Playwright on:
+- Desktop: 1280×800 — expense cards and modal confirmed correct
+- Mobile: 390×844 — layout wraps correctly, no overflow issues


### PR DESCRIPTION
## Summary

- Rename "By Share" split mode to **"By Participant members"** in the expense create/update modal (label, aria-label, info modal title and description — updated with a restaurant example)
- Add always-visible **participant amounts** on expense cards in `Name: €XX.XX · Name: €XX.XX` format, filtered to non-zero amounts, wrapping across lines for groups with many participants
- Fix missing `BY_SHARE` badge label in `ExpenseCard.svelte` and `ExpenseList.svelte` → "By Members"

Closes #114

## Test plan

- [x] `EditExpenseModal.test.ts` — updated 4 assertions for "By Participant members" label
- [x] `AddExpenseModal.test.ts` — updated 4 assertions + test descriptions
- [x] `ExpenseList.test.ts` — replaced "Everyone" test, added 2 new tests (participant amounts format, zero-amount filtering, BY_SHARE badge)
- [x] 150 tests passing
- [x] Visual verification on mobile (390×844) and desktop (1280×800) via Playwright

🤖 Generated with [Claude Code](https://claude.com/claude-code)