### PR TITLE
fix: use SecureRandom for CAPTCHA crypto operations (#125, #137)

### DIFF
--- a/fairnsquare-app/src/main/doc/implementation/2026-04-25-Bugfix-SecureRandom-Captcha.md
+++ b/fairnsquare-app/src/main/doc/implementation/2026-04-25-Bugfix-SecureRandom-Captcha.md
@@ -1,0 +1,39 @@
+# Bugfix: Use SecureRandom for CAPTCHA cryptographic operations
+
+## What, Why and Constraints
+
+**What**: Replaced `java.util.Random` with `java.security.SecureRandom` in `CaptchaService`. The single field `private final Random random = new Random()` is now `private final SecureRandom random = new SecureRandom()`. All four call sites (AES-GCM IV generation, two `nextInt` calls for challenge/distractor values, and `Collections.shuffle`) are unchanged.
+
+**Why**: `CaptchaService` used the same `Random` instance to generate AES-GCM initialization vectors. `java.util.Random` is a Linear Congruential Generator with 48-bit internal state — given a few outputs, an attacker can recover the seed and predict every subsequent IV. AES-GCM requires unique, unpredictable IVs per key: an IV collision under the same key catastrophically breaks both confidentiality (XOR of plaintexts leaks) and authenticity (forgeable tags via authentication-key recovery). Predictable IVs also enable IV-collision attacks via birthday bound. This fix closes GitHub issues #125 (insecure RNG for crypto IV) and #137 (predictable challenge values usable to bypass CAPTCHA).
+
+**Constraints** (from `src/doc/rules/backend-rules.md`):
+- No CDI interceptor changes, no module boundary changes, no domain mutation, no test-only code added to `src/main/java`.
+- No new logging added (existing service has none).
+- No persistence DTO touched, no scheduled job, no `@QuarkusTestResource` change.
+
+## How
+
+### Files modified
+
+**`fairnsquare-app/src/main/java/org/asymetrik/web/fairnsquare/infrastructure/captcha/service/CaptchaService.java`**
+- Replaced `import java.util.Random;` with `import java.security.SecureRandom;`.
+- Changed field declaration from `private final Random random = new Random();` to `private final SecureRandom random = new SecureRandom();`.
+- All four usage sites compile and behave identically because `SecureRandom` extends `Random`:
+  - `random.nextInt(9)` for operands a, b (generateChallenge)
+  - `random.nextBytes(iv)` for the AES-GCM IV (encryptChallenge) — the security-critical site
+  - `random.nextInt(17)` for distractor candidates (buildShuffledAnswers)
+  - `Collections.shuffle(all, random)` for answer-area ordering
+
+### Why no other files changed
+
+- The existing test `encryptChallenge_twoCallsProduceDifferentTokens` already proves IVs differ across calls; with `SecureRandom`, the property now holds for cryptographic reasons, not statistical accident.
+- `SecureRandom` is a drop-in subtype, so signatures, callers, persistence, and JSON serialization are unaffected.
+- No test asserts the concrete RNG class — adding such an assertion would test the framework rather than behaviour.
+
+## Tests
+
+**Automated regression check** — `mvn test -pl fairnsquare-app -Dquarkus.quinoa.run-tests=false`:
+- `CaptchaServiceTest`: 24/24 passing (challenge generation, AES-GCM round-trip, stateless verification, token validation, secret fingerprint, AnswerArea contains).
+- Full backend suite: **313/313 passing**, no failures, no skips.
+
+**Manual verification not required** — change is a transparent algorithmic upgrade with identical observable behaviour at the public API.

--- a/fairnsquare-app/src/main/java/org/asymetrik/web/fairnsquare/infrastructure/captcha/service/CaptchaService.java
+++ b/fairnsquare-app/src/main/java/org/asymetrik/web/fairnsquare/infrastructure/captcha/service/CaptchaService.java
@@ -2,6 +2,7 @@ package org.asymetrik.web.fairnsquare.infrastructure.captcha.service;
 
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
+import java.security.SecureRandom;
 import java.util.HexFormat;
 import java.time.Duration;
 import java.time.Instant;
@@ -11,7 +12,6 @@ import java.util.Base64;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.util.Random;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -47,7 +47,7 @@ public class CaptchaService {
     private static final Base64.Encoder B64_ENC = Base64.getUrlEncoder().withoutPadding();
     private static final Base64.Decoder B64_DEC = Base64.getUrlDecoder();
 
-    private final Random random = new Random();
+    private final SecureRandom random = new SecureRandom();
 
     @ConfigProperty(name = "captcha.secret", defaultValue = "change-me-in-production")
     String secret;

--- a/src/doc/rules/backend-rules.md
+++ b/src/doc/rules/backend-rules.md
@@ -90,3 +90,9 @@
 ## Expense Update — SplitMode Constraints
 
 - `split.updateExpense(id, amount, description, payer, SplitMode)` delegates to `Expense.fromJson()`, which cannot construct a `FREE` expense (FREE requires explicit per-participant shares that are not part of the update request signature). Tests exercising `updateExpense` must use `BY_NIGHT` or `BY_SHARE`. The `updateExpense` method must document this constraint with a `@throws UnsupportedOperationException` if `SplitMode.FREE` is passed.
+
+## Cryptographic Randomness
+
+- Any randomness consumed by a cryptographic operation — AES/GCM IVs, salts, nonces, key material, signed tokens, CAPTCHA challenges, anti-CSRF values — must come from `java.security.SecureRandom`. `java.util.Random`, `Math.random()`, and `ThreadLocalRandom` are forbidden in security-sensitive paths because they expose predictable internal state (LCG, 48-bit seed) that an attacker can recover from a handful of outputs.
+- A single `SecureRandom` instance per service is sufficient — it is thread-safe and avoids per-call seeding cost.
+- Non-cryptographic randomness (test fixtures, dev seeders, UI animations, jitter for backoff) may continue to use `java.util.Random` or `ThreadLocalRandom`. The boundary is "would predictability give an attacker leverage?", not "is this code in `infrastructure/`?".


### PR DESCRIPTION
## Summary

- Replace `java.util.Random` with `java.security.SecureRandom` in `CaptchaService` — the same instance was generating both AES-GCM IVs and CAPTCHA challenge values.
- `java.util.Random` is a 48-bit LCG; given a few outputs an attacker can recover its state and predict every subsequent IV. Predictable IVs under the same key break GCM confidentiality and authenticity, and predictable challenges trivially defeat the CAPTCHA.
- `SecureRandom extends Random`, so all four call sites (IV generation, two `nextInt`, `Collections.shuffle`) compile and behave unchanged.
- Adds a new "Cryptographic Randomness" rule to `src/doc/rules/backend-rules.md` to prevent regressions.

Closes #125, closes #137.

## Test plan

- [x] `mvn test -pl fairnsquare-app -Dtest=CaptchaServiceTest` — 24/24 passing
- [x] `mvn test -pl fairnsquare-app -Dquarkus.quinoa.run-tests=false` — full backend suite 313/313 passing
- [x] No frontend changes; frontend tests N/A
- [ ] Manual smoke: open a CAPTCHA in dev, confirm challenge image still renders and answer flow still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)