### PR TITLE
fix(captcha): randomise box positions in 2x2 grid (#143)

### DIFF
--- a/fairnsquare-app/src/main/doc/implementation/2026-04-26-Bugfix-Randomise-Captcha-Positions.md
+++ b/fairnsquare-app/src/main/doc/implementation/2026-04-26-Bugfix-Randomise-Captcha-Positions.md
@@ -1,0 +1,62 @@
+# Bugfix: Randomise CAPTCHA box positions to defeat blind-click bypass
+
+## What, Why and Constraints
+
+**What**: Replaced the fixed 1×4 row of CAPTCHA answer boxes with a 2×2 grid where each box's `(x, y)` is randomly jittered inside its grid cell on every challenge. The image grew from 400×160 to 400×280 to give the grid the room it needs.
+
+**Why**: All four answer boxes used to share the same `y` coordinate and a deterministic stride along `x`. Only the *values* shown were shuffled — the *positions* never changed across challenges. A bot scripting the endpoint could click any fixed coordinate inside the bottom strip and succeed with probability **1/4 per attempt** without rendering the image. Combined with the absence of rate limiting (#129), this gave bots a ~4-request cost per successful split. The fix randomises positions on every challenge so the attacker no longer knows where to click — blind-click attacks now reduce to clicking randomly in a much larger area.
+
+**Constraints** (from `src/doc/rules/backend-rules.md`):
+- Randomness used for position layout is consumed by SecureRandom (the same field already used for AES-GCM IVs after #125), satisfying the new "Cryptographic Randomness" rule even though box positions aren't strictly cryptographic.
+- No CDI interceptor, no module boundary change, no domain mutation method touched, no test-only code added to `src/main/java`.
+- Frontend production code untouched — `CaptchaModal.svelte` already scales clicks via `imgElement.naturalWidth/Height`, so growing the image required no rendering change.
+
+## How
+
+### Files modified
+
+**`fairnsquare-app/src/main/java/org/asymetrik/web/fairnsquare/infrastructure/captcha/domain/CaptchaChallenge.java`**
+- `IMAGE_HEIGHT`: 160 → 280.
+- Added `TOP_ZONE_HEIGHT = 80` constant — the vertical band reserved for the question text. Boxes are placed below this zone.
+
+**`fairnsquare-app/src/main/java/org/asymetrik/web/fairnsquare/infrastructure/captcha/service/CaptchaService.java`**
+- Removed row-layout constants `BOX_MARGIN`, `BOX_Y` (no longer needed).
+- Added grid constants: `GRID_ROWS=2`, `GRID_COLS=2`, `BOX_WIDTH=90`, `BOX_HEIGHT=60`, `CELL_PADDING=8`.
+- Rewrote the position-assignment loop in `generateChallenge()`:
+  - Compute `cellWidth = IMAGE_WIDTH / GRID_COLS = 200`, `cellHeight = (IMAGE_HEIGHT - TOP_ZONE_HEIGHT) / GRID_ROWS = 100`.
+  - Compute jitter ranges: `jitterX = cellWidth - BOX_WIDTH - 2*CELL_PADDING = 94`, `jitterY = cellHeight - BOX_HEIGHT - 2*CELL_PADDING = 24`.
+  - For each `i ∈ [0..3]`: cell at `(row=i/2, col=i%2)`, then place the box at `cellOriginX + random.nextInt(jitterX+1)`, `cellOriginY + random.nextInt(jitterY+1)`.
+- Boxes are guaranteed non-overlapping by construction because each is constrained to its own padded cell.
+- Random source unchanged: still the `SecureRandom random` field introduced by #125.
+
+**`fairnsquare-app/src/main/java/org/asymetrik/web/fairnsquare/infrastructure/captcha/CaptchaImageGenerator.java`**
+- `drawQuestion` previously computed vertical centering using `challenge.answerAreas().get(0).height()` — a leak from the row-layout assumption that all boxes shared a baseline. Replaced with `(TOP_ZONE_HEIGHT - fm.getHeight()) / 2 + fm.getAscent()` so the question stays cleanly inside the reserved 80-pixel top band regardless of where boxes land.
+
+**`fairnsquare-app/src/test/java/org/asymetrik/web/fairnsquare/captcha/CaptchaServiceTest.java`**
+- Added imports `HashSet`, `List`, `Set`.
+- Added 3 tests:
+  - `generateChallenge_boxesAreInsideImageBounds` — across 50 challenges, every box lies within `[0, IMAGE_WIDTH] × [TOP_ZONE_HEIGHT, IMAGE_HEIGHT]`.
+  - `generateChallenge_boxesDoNotOverlap` — across 50 challenges, no pair of boxes overlaps. Catches any future cell-padding regression.
+  - `generateChallenge_boxPositionsVaryAcrossChallenges` — across 30 challenges, box 0's `(x,y)` takes more than one distinct value. Catches any regression to a fixed-position layout.
+- Added private helper `rectanglesOverlap(a, b)`.
+
+**`fairnsquare-app/src/main/webui/src/lib/components/ui/captcha/CaptchaModal.test.ts`**
+- Updated three hardcoded `naturalHeight: 160` values to `280`, and three `getBoundingClientRect` mocks' `height: 160` to `280`. Production frontend code is unchanged; only the mocks needed to mirror the new image dimensions.
+
+### Why no other files changed
+
+- `CaptchaChallenge.AnswerArea.contains(px, py)` already uses arbitrary `(x, y, w, h)` — no layout assumption.
+- `CaptchaService.encryptChallenge` / `verifyAnswer` carry the correct box's bounds in the AES-GCM token, completely independent of layout. Token format is unchanged.
+- Frontend `CaptchaModal.svelte` reads `imgElement.naturalWidth/Height` to scale clicks — works for any image dimensions.
+
+## Tests
+
+Backend (`mvn test -pl fairnsquare-app -Dquarkus.quinoa.run-tests=false`):
+- `CaptchaServiceTest`: **27/27 passing** (24 original + 3 new).
+- Full backend suite: **316/316 passing**, no failures, no skips.
+
+Frontend (`npm run test:run` from `fairnsquare-app/src/main/webui`):
+- `CaptchaModal.test.ts`: **12/12 passing**.
+- Full frontend suite: **511/511 passing** across 21 test files.
+
+Manual verification recommended (not blocking): open the dev server, request a CAPTCHA, click "New challenge" several times, confirm boxes visibly move and never overlap.

--- a/fairnsquare-app/src/main/java/org/asymetrik/web/fairnsquare/infrastructure/captcha/CaptchaImageGenerator.java
+++ b/fairnsquare-app/src/main/java/org/asymetrik/web/fairnsquare/infrastructure/captcha/CaptchaImageGenerator.java
@@ -87,7 +87,7 @@ public class CaptchaImageGenerator {
         FontMetrics fm = g.getFontMetrics();
         int textWidth = fm.stringWidth(question);
         int x = (CaptchaChallenge.IMAGE_WIDTH - textWidth) / 2;
-        int y = (CaptchaChallenge.IMAGE_HEIGHT - challenge.answerAreas().get(0).height() - 40) / 2 + fm.getAscent();
+        int y = (CaptchaChallenge.TOP_ZONE_HEIGHT - fm.getHeight()) / 2 + fm.getAscent();
         g.drawString(question, x, y);
     }
 

--- a/fairnsquare-app/src/main/java/org/asymetrik/web/fairnsquare/infrastructure/captcha/domain/CaptchaChallenge.java
+++ b/fairnsquare-app/src/main/java/org/asymetrik/web/fairnsquare/infrastructure/captcha/domain/CaptchaChallenge.java
@@ -17,7 +17,12 @@ public record CaptchaChallenge(int operandA, int operandB, List<AnswerArea> answ
     public static final int IMAGE_WIDTH = 400;
 
     /** Height of the generated CAPTCHA image in pixels. */
-    public static final int IMAGE_HEIGHT = 160;
+    public static final int IMAGE_HEIGHT = 280;
+
+    /**
+     * Vertical extent reserved for the question text at the top of the image. Answer boxes are placed below this zone.
+     */
+    public static final int TOP_ZONE_HEIGHT = 80;
 
     /**
      * A clickable answer area on the CAPTCHA image.

--- a/fairnsquare-app/src/main/java/org/asymetrik/web/fairnsquare/infrastructure/captcha/service/CaptchaService.java
+++ b/fairnsquare-app/src/main/java/org/asymetrik/web/fairnsquare/infrastructure/captcha/service/CaptchaService.java
@@ -33,11 +33,14 @@ import org.eclipse.microprofile.config.inject.ConfigProperty;
 @ApplicationScoped
 public class CaptchaService {
 
-    // Answer area layout constants
+    // Answer area layout constants — boxes are placed in a 2x2 grid below TOP_ZONE_HEIGHT, with each box randomly
+    // jittered inside its grid cell so the click coordinates differ between challenges (defeats blind-click bypass).
     private static final int ANSWER_AREA_COUNT = 4;
-    private static final int BOX_MARGIN = 20;
-    private static final int BOX_HEIGHT = 50;
-    private static final int BOX_Y = CaptchaChallenge.IMAGE_HEIGHT - BOX_HEIGHT - BOX_MARGIN;
+    private static final int GRID_ROWS = 2;
+    private static final int GRID_COLS = 2;
+    private static final int BOX_WIDTH = 90;
+    private static final int BOX_HEIGHT = 60;
+    private static final int CELL_PADDING = 8;
 
     // AES-GCM constants
     private static final String AES_CIPHER = "AES/GCM/NoPadding";
@@ -71,15 +74,25 @@ public class CaptchaService {
 
         List<Integer> allAnswers = buildShuffledAnswers(correctAnswer);
 
-        int boxWidth = (CaptchaChallenge.IMAGE_WIDTH - (ANSWER_AREA_COUNT + 1) * BOX_MARGIN) / ANSWER_AREA_COUNT;
+        int cellWidth = CaptchaChallenge.IMAGE_WIDTH / GRID_COLS;
+        int cellHeight = (CaptchaChallenge.IMAGE_HEIGHT - CaptchaChallenge.TOP_ZONE_HEIGHT) / GRID_ROWS;
+        int jitterX = cellWidth - BOX_WIDTH - 2 * CELL_PADDING;
+        int jitterY = cellHeight - BOX_HEIGHT - 2 * CELL_PADDING;
+
         List<CaptchaChallenge.AnswerArea> areas = new ArrayList<>();
         String correctAreaId = null;
 
         for (int i = 0; i < ANSWER_AREA_COUNT; i++) {
-            int x = BOX_MARGIN + i * (boxWidth + BOX_MARGIN);
+            int row = i / GRID_COLS;
+            int col = i % GRID_COLS;
+            int cellOriginX = col * cellWidth + CELL_PADDING;
+            int cellOriginY = CaptchaChallenge.TOP_ZONE_HEIGHT + row * cellHeight + CELL_PADDING;
+            int x = cellOriginX + random.nextInt(jitterX + 1);
+            int y = cellOriginY + random.nextInt(jitterY + 1);
+
             int answer = allAnswers.get(i);
             String id = CaptchaChallenge.generateId().substring(0, 8);
-            areas.add(new CaptchaChallenge.AnswerArea(id, x, BOX_Y, boxWidth, BOX_HEIGHT, answer));
+            areas.add(new CaptchaChallenge.AnswerArea(id, x, y, BOX_WIDTH, BOX_HEIGHT, answer));
             if (answer == correctAnswer && correctAreaId == null) {
                 correctAreaId = id;
             }

--- a/fairnsquare-app/src/main/webui/src/lib/components/ui/captcha/CaptchaModal.test.ts
+++ b/fairnsquare-app/src/main/webui/src/lib/components/ui/captcha/CaptchaModal.test.ts
@@ -100,9 +100,9 @@ describe('CaptchaModal', () => {
     const img = await screen.findByAltText(/click the correct answer/i);
 
     Object.defineProperty(img, 'naturalWidth', { value: 400 });
-    Object.defineProperty(img, 'naturalHeight', { value: 160 });
+    Object.defineProperty(img, 'naturalHeight', { value: 280 });
     Object.defineProperty(img, 'getBoundingClientRect', {
-      value: () => ({ left: 0, top: 0, width: 400, height: 160 }),
+      value: () => ({ left: 0, top: 0, width: 400, height: 280 }),
     });
 
     await fireEvent.click(img, { clientX: 100, clientY: 120 });
@@ -120,9 +120,9 @@ describe('CaptchaModal', () => {
 
     const img = await screen.findByAltText(/click the correct answer/i);
     Object.defineProperty(img, 'naturalWidth', { value: 400 });
-    Object.defineProperty(img, 'naturalHeight', { value: 160 });
+    Object.defineProperty(img, 'naturalHeight', { value: 280 });
     Object.defineProperty(img, 'getBoundingClientRect', {
-      value: () => ({ left: 0, top: 0, width: 400, height: 160 }),
+      value: () => ({ left: 0, top: 0, width: 400, height: 280 }),
     });
 
     await fireEvent.click(img, { clientX: 100, clientY: 120 });
@@ -148,9 +148,9 @@ describe('CaptchaModal', () => {
 
     const img = await screen.findByAltText(/click the correct answer/i);
     Object.defineProperty(img, 'naturalWidth', { value: 400 });
-    Object.defineProperty(img, 'naturalHeight', { value: 160 });
+    Object.defineProperty(img, 'naturalHeight', { value: 280 });
     Object.defineProperty(img, 'getBoundingClientRect', {
-      value: () => ({ left: 0, top: 0, width: 400, height: 160 }),
+      value: () => ({ left: 0, top: 0, width: 400, height: 280 }),
     });
 
     await fireEvent.click(img, { clientX: 5, clientY: 5 });
@@ -167,9 +167,9 @@ describe('CaptchaModal', () => {
 
     const img = await screen.findByAltText(/click the correct answer/i);
     Object.defineProperty(img, 'naturalWidth', { value: 400 });
-    Object.defineProperty(img, 'naturalHeight', { value: 160 });
+    Object.defineProperty(img, 'naturalHeight', { value: 280 });
     Object.defineProperty(img, 'getBoundingClientRect', {
-      value: () => ({ left: 0, top: 0, width: 400, height: 160 }),
+      value: () => ({ left: 0, top: 0, width: 400, height: 280 }),
     });
 
     await fireEvent.click(img, { clientX: 5, clientY: 5 });

--- a/fairnsquare-app/src/test/java/org/asymetrik/web/fairnsquare/captcha/CaptchaServiceTest.java
+++ b/fairnsquare-app/src/test/java/org/asymetrik/web/fairnsquare/captcha/CaptchaServiceTest.java
@@ -2,7 +2,10 @@ package org.asymetrik.web.fairnsquare.captcha;
 
 import java.lang.reflect.Field;
 import java.time.Instant;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import org.asymetrik.web.fairnsquare.infrastructure.captcha.domain.CaptchaChallenge;
 import org.asymetrik.web.fairnsquare.infrastructure.captcha.domain.CaptchaToken;
@@ -65,6 +68,52 @@ class CaptchaServiceTest {
                 .map(CaptchaChallenge.AnswerArea::answer).orElseThrow();
 
         assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    void generateChallenge_boxesAreInsideImageBounds() {
+        for (int i = 0; i < 50; i++) {
+            CaptchaChallenge challenge = service.generateChallenge();
+            for (CaptchaChallenge.AnswerArea area : challenge.answerAreas()) {
+                assertThat(area.x()).isGreaterThanOrEqualTo(0);
+                assertThat(area.y()).isGreaterThanOrEqualTo(CaptchaChallenge.TOP_ZONE_HEIGHT);
+                assertThat(area.x() + area.width()).isLessThanOrEqualTo(CaptchaChallenge.IMAGE_WIDTH);
+                assertThat(area.y() + area.height()).isLessThanOrEqualTo(CaptchaChallenge.IMAGE_HEIGHT);
+            }
+        }
+    }
+
+    @Test
+    void generateChallenge_boxesDoNotOverlap() {
+        for (int run = 0; run < 50; run++) {
+            CaptchaChallenge challenge = service.generateChallenge();
+            List<CaptchaChallenge.AnswerArea> areas = challenge.answerAreas();
+            for (int i = 0; i < areas.size(); i++) {
+                for (int j = i + 1; j < areas.size(); j++) {
+                    assertThat(rectanglesOverlap(areas.get(i), areas.get(j)))
+                            .as("Boxes %d and %d must not overlap (run %d)", i, j, run).isFalse();
+                }
+            }
+        }
+    }
+
+    @Test
+    void generateChallenge_boxPositionsVaryAcrossChallenges() {
+        // Defeats the blind-click attack: positions must NOT be the same across challenges.
+        // With 95x25 jitter range per cell, the probability that 30 challenges all place box 0 at the same (x,y)
+        // is astronomically small (~(1/2375)^29).
+        Set<String> firstBoxPositions = new HashSet<>();
+        for (int i = 0; i < 30; i++) {
+            CaptchaChallenge challenge = service.generateChallenge();
+            CaptchaChallenge.AnswerArea first = challenge.answerAreas().get(0);
+            firstBoxPositions.add(first.x() + "," + first.y());
+        }
+        assertThat(firstBoxPositions).as("Box 0 position must vary across challenges").hasSizeGreaterThan(1);
+    }
+
+    private static boolean rectanglesOverlap(CaptchaChallenge.AnswerArea a, CaptchaChallenge.AnswerArea b) {
+        return a.x() < b.x() + b.width() && a.x() + a.width() > b.x() && a.y() < b.y() + b.height()
+                && a.y() + a.height() > b.y();
     }
 
     // --- Challenge encryption (stateless token) ---


### PR DESCRIPTION
## Summary

- Replaced the fixed 1×4 row of answer boxes with a 2×2 grid where each box is randomly jittered inside its cell on every challenge.
- Answer boxes used to share the same `y` and a deterministic `x` stride — a bot could click a fixed coordinate and succeed with **25% probability per attempt** without ever rendering the image.
- With per-challenge jitter (~95×25 px per cell via `SecureRandom`), an attacker can no longer memorise click coordinates. Boxes are guaranteed non-overlapping by construction (each constrained to its own padded cell).
- Image grew from 400×160 to 400×280 to accommodate the 2×2 grid. Frontend production code untouched — `CaptchaModal.svelte` already scales clicks via `imgElement.naturalWidth/Height`.
- Fixed a latent bug in `CaptchaImageGenerator.drawQuestion` that derived vertical centering from `answerAreas.get(0).height()` (row-layout assumption leaked into the renderer).

Closes #143.

## Test plan

- [x] `CaptchaServiceTest` — 27/27 passing (24 original + 3 new: in-bounds, no-overlap, position-variance across 30 challenges)
- [x] Full backend suite — 316/316 passing
- [x] `CaptchaModal.test.ts` — 12/12 passing (mock `naturalHeight` updated to 280)
- [x] Full frontend suite — 511/511 passing across 21 test files
- [ ] Manual smoke: open dev server, request a CAPTCHA several times, confirm boxes visibly move between challenges and never overlap the question text

🤖 Generated with [Claude Code](https://claude.com/claude-code)