### PR TITLE
fix(security): constant-time comparisons and required CAPTCHA secret (#126, #127, #128)

### DIFF
--- a/fairnsquare-app/src/main/doc/implementation/2026-04-26-Bugfix-ConstantTime-And-Secret-Validation.md
+++ b/fairnsquare-app/src/main/doc/implementation/2026-04-26-Bugfix-ConstantTime-And-Secret-Validation.md
@@ -1,0 +1,62 @@
+# Bugfix: Constant-time token comparison and required CAPTCHA secret
+
+## What, Why and Constraints
+
+**What**: Three related security fixes bundled in one PR (closes #126, #127, #128):
+
+1. **#128 — Constant-time HMAC compare in `CaptchaToken`**: replaced `String.equals` with `MessageDigest.isEqual` for HMAC signature verification.
+2. **#127 — Constant-time SHA-256 compare in `AdminTokenFilter`**: replaced `equalsIgnoreCase` with a constant-time byte comparison; also fixed the case-insensitivity bug (`equalsIgnoreCase` treated `A` as equal to `a`, which is wrong for hex digests).
+3. **#126 — Required CAPTCHA secret in production**: removed `defaultValue = "change-me-in-production"` from `@ConfigProperty`, making `CAPTCHA_SECRET` a required env var in prod. Quarkus will refuse to start if it is absent.
+
+**Why**:
+
+- **#128/#127 (timing oracles)**: `String.equals` and `equalsIgnoreCase` both short-circuit on the first differing byte, leaking timing information proportional to the length of the common prefix. An attacker making many repeated requests can statistically infer bytes of the HMAC signature or SHA-256 hash. `MessageDigest.isEqual` runs in constant time regardless of content.
+- **#127 additional**: `equalsIgnoreCase` accepted mixed-case hex strings (`A` == `a`), effectively doubling the search space for a brute-force attacker and producing incorrect rejections if the stored hash used a different case than the computed one. Constant-case comparison (lowercase normalisation + `MessageDigest.isEqual`) is both secure and unambiguous.
+- **#126 (weak default secret)**: With `defaultValue = "change-me-in-production"`, any production deployment that forgot to set `CAPTCHA_SECRET` silently ran with a well-known secret. An attacker knowing this value could forge CAPTCHA proof tokens and bypass bot protection on `POST /api/splits`. The fix makes the absence of the env var a hard startup failure.
+
+**Constraints** (from `src/doc/rules/backend-rules.md`):
+- No CDI interceptor change, no domain model change, no module boundary change.
+- `ADMIN_TOKEN_HEADER` made `public` because test code in a different package (`admin`) needed access — consistent with the rule that fields required by test code or sibling classes must be explicitly `public`.
+- No Mockito or other new test dependency introduced — `AdminTokenFilter` is tested with a plain inline `ContainerRequestContext` stub.
+
+## How
+
+### Files modified
+
+**`fairnsquare-app/src/main/java/org/asymetrik/web/fairnsquare/infrastructure/captcha/domain/CaptchaToken.java`** (#128)
+- Added `import java.security.MessageDigest`.
+- Replaced `!expectedSig.equals(parts[1])` with `!MessageDigest.isEqual(expectedSig.getBytes(UTF_8), parts[1].getBytes(UTF_8))`. Both operands are base64url-encoded HMAC outputs, so comparing their UTF-8 byte representations is equivalent to comparing the underlying HMAC bytes.
+
+**`fairnsquare-app/src/main/java/org/asymetrik/web/fairnsquare/admin/api/internal/AdminTokenFilter.java`** (#127)
+- Made `ADMIN_TOKEN_HEADER` `public` (was package-private; test code in a different package needs it).
+- Added `import java.util.HexFormat`.
+- Removed `import java.util.HexFormat` — wait, it was already there and removed in the refactor; re-added via import.
+- Refactored `sha256Hex(String) → String` into `sha256Bytes(String) → byte[]` (returns raw digest bytes).
+- Added `constantTimeHashEquals(byte[] computed, String storedHex)`: lowercases `storedHex`, parses it back to bytes with `HexFormat.of().parseHex(...)`, then compares with `MessageDigest.isEqual`. The `try/catch` around the hex parse returns `false` on malformed stored hashes (maps to 401, not 500).
+- Updated `filter()` call: `!sha256Hex(token).equalsIgnoreCase(passwordHash)` → `!constantTimeHashEquals(sha256Bytes(token), passwordHash)`.
+
+**`fairnsquare-app/src/main/java/org/asymetrik/web/fairnsquare/infrastructure/captcha/service/CaptchaService.java`** (#126)
+- Removed `defaultValue = "change-me-in-production"` from `@ConfigProperty(name = "captcha.secret")`. The property is now required by Quarkus in any profile that does not provide a profile-specific override.
+
+**`fairnsquare-app/src/main/resources/application.properties`** (#126)
+- Changed `captcha.secret=${CAPTCHA_SECRET:change-me-in-production}` to `captcha.secret=${CAPTCHA_SECRET}` (no fallback → required in prod).
+- Added `%dev.captcha.secret=change-me-in-production` (dev profile retains the old placeholder, committed since it is not a real secret).
+- Added `%test.captcha.secret=change-me-in-test` (test profile uses a distinct placeholder to avoid confusion with the dev value).
+
+**`fairnsquare-app/src/test/java/org/asymetrik/web/fairnsquare/CaptchaTokenTestHelper.java`** (#126)
+- Updated `TEST_SECRET` from `"change-me-in-production"` to `"change-me-in-test"` to match `%test.captcha.secret`. Integration tests that use this helper to generate signed CAPTCHA tokens for the `X-Captcha-Token` header now produce tokens that the test-profile server validates correctly.
+
+### Files created
+
+**`fairnsquare-app/src/test/java/org/asymetrik/web/fairnsquare/admin/AdminTokenFilterTest.java`** (#127)
+- 6 plain-JUnit tests using an inline `ContainerRequestContext` stub (no Mockito).
+- Covers: valid token passes, wrong token → 401, missing token → 401, uppercase stored hash still validates, unconfigured hash → 503, malformed hex hash → 401.
+
+## Tests
+
+Backend (`mvn test -pl fairnsquare-app -Dquarkus.quinoa.run-tests=false`):
+- `CaptchaServiceTest`: 27/27 passing (HMAC round-trip tests cover the constant-time path indirectly).
+- `AdminTokenFilterTest`: 6/6 passing (new).
+- Full backend suite: **322/322 passing**, no failures, no skips.
+
+No frontend changes — no frontend tests needed.

--- a/fairnsquare-app/src/main/java/org/asymetrik/web/fairnsquare/admin/api/internal/AdminTokenFilter.java
+++ b/fairnsquare-app/src/main/java/org/asymetrik/web/fairnsquare/admin/api/internal/AdminTokenFilter.java
@@ -27,7 +27,7 @@ import org.eclipse.microprofile.config.inject.ConfigProperty;
 @AdminProtected
 public class AdminTokenFilter implements ContainerRequestFilter {
 
-    static final String ADMIN_TOKEN_HEADER = "X-Admin-Token";
+    public static final String ADMIN_TOKEN_HEADER = "X-Admin-Token";
 
     private final String passwordHash;
 
@@ -44,7 +44,7 @@ public class AdminTokenFilter implements ContainerRequestFilter {
         }
 
         String token = requestContext.getHeaderString(ADMIN_TOKEN_HEADER);
-        if (token == null || !sha256Hex(token).equalsIgnoreCase(passwordHash)) {
+        if (token == null || !constantTimeHashEquals(sha256Bytes(token), passwordHash)) {
             requestContext.abortWith(buildResponse(401, "Invalid or missing admin token."));
         }
     }
@@ -54,13 +54,23 @@ public class AdminTokenFilter implements ContainerRequestFilter {
         return Response.status(status).type(MediaType.APPLICATION_JSON).entity(body).build();
     }
 
-    private static String sha256Hex(String input) {
+    private static byte[] sha256Bytes(String input) {
         try {
-            MessageDigest digest = MessageDigest.getInstance("SHA-256");
-            byte[] hash = digest.digest(input.getBytes(StandardCharsets.UTF_8));
-            return HexFormat.of().formatHex(hash);
+            return MessageDigest.getInstance("SHA-256").digest(input.getBytes(StandardCharsets.UTF_8));
         } catch (NoSuchAlgorithmException e) {
             throw new IllegalStateException("SHA-256 algorithm not available", e);
+        }
+    }
+
+    // Constant-time comparison: parse the stored hex hash to bytes and compare with MessageDigest.isEqual
+    // to prevent timing oracles on the password hash. Lowercasing the stored hash normalises any case variation
+    // in the configured value without accepting mixed-case via equalsIgnoreCase (which was also timing-leaky).
+    private static boolean constantTimeHashEquals(byte[] computed, String storedHex) {
+        try {
+            byte[] stored = HexFormat.of().parseHex(storedHex.toLowerCase());
+            return MessageDigest.isEqual(computed, stored);
+        } catch (Exception e) {
+            return false;
         }
     }
 }

--- a/fairnsquare-app/src/main/java/org/asymetrik/web/fairnsquare/infrastructure/captcha/domain/CaptchaToken.java
+++ b/fairnsquare-app/src/main/java/org/asymetrik/web/fairnsquare/infrastructure/captcha/domain/CaptchaToken.java
@@ -1,6 +1,7 @@
 package org.asymetrik.web.fairnsquare.infrastructure.captcha.domain;
 
 import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
 import java.time.Instant;
 import java.util.Base64;
 
@@ -52,9 +53,10 @@ public record CaptchaToken(String value) {
         if (parts.length != 2) {
             return false;
         }
-        // Verify signature
+        // Constant-time signature comparison — prevents timing oracle on HMAC bytes
         String expectedSig = hmac(parts[0], secret);
-        if (!expectedSig.equals(parts[1])) {
+        if (!MessageDigest.isEqual(expectedSig.getBytes(StandardCharsets.UTF_8),
+                parts[1].getBytes(StandardCharsets.UTF_8))) {
             return false;
         }
         // Verify expiry

--- a/fairnsquare-app/src/main/java/org/asymetrik/web/fairnsquare/infrastructure/captcha/service/CaptchaService.java
+++ b/fairnsquare-app/src/main/java/org/asymetrik/web/fairnsquare/infrastructure/captcha/service/CaptchaService.java
@@ -52,7 +52,7 @@ public class CaptchaService {
 
     private final SecureRandom random = new SecureRandom();
 
-    @ConfigProperty(name = "captcha.secret", defaultValue = "change-me-in-production")
+    @ConfigProperty(name = "captcha.secret")
     String secret;
 
     @ConfigProperty(name = "captcha.challenge-ttl-seconds", defaultValue = "300")

--- a/fairnsquare-app/src/main/resources/application.properties
+++ b/fairnsquare-app/src/main/resources/application.properties
@@ -74,8 +74,12 @@ fairnsquare.storage.max-file-age-days=${FAIRNSQUARE_MAX_FILE_AGE_DAYS:90}
 # =============================================================================
 # CAPTCHA Configuration
 # =============================================================================
-# HMAC-SHA256 signing secret for CAPTCHA tokens (override in production via env var)
-captcha.secret=${CAPTCHA_SECRET:change-me-in-production}
+# HMAC-SHA256 signing secret for CAPTCHA tokens — required in prod via CAPTCHA_SECRET env var
+# No default: Quarkus will refuse to start in prod if the env var is absent
+captcha.secret=${CAPTCHA_SECRET}
+# Dev and test use a known placeholder — never used in production
+%dev.captcha.secret=change-me-in-production
+%test.captcha.secret=change-me-in-test
 # How long a challenge stays valid (seconds)
 captcha.challenge-ttl-seconds=${CAPTCHA_CHALLENGE_TTL_SECONDS:300}
 # How long a solved token stays valid (seconds, default 1 hour)

--- a/fairnsquare-app/src/test/java/org/asymetrik/web/fairnsquare/CaptchaTokenTestHelper.java
+++ b/fairnsquare-app/src/test/java/org/asymetrik/web/fairnsquare/CaptchaTokenTestHelper.java
@@ -10,8 +10,8 @@ import org.asymetrik.web.fairnsquare.infrastructure.captcha.domain.CaptchaToken;
  */
 public final class CaptchaTokenTestHelper {
 
-    /** The default secret used in tests (matches application.properties default). */
-    private static final String TEST_SECRET = "change-me-in-production";
+    /** The secret used in tests (matches %test.captcha.secret in application.properties). */
+    private static final String TEST_SECRET = "change-me-in-test";
 
     private CaptchaTokenTestHelper() {
     }

--- a/fairnsquare-app/src/test/java/org/asymetrik/web/fairnsquare/admin/AdminTokenFilterTest.java
+++ b/fairnsquare-app/src/test/java/org/asymetrik/web/fairnsquare/admin/AdminTokenFilterTest.java
@@ -1,0 +1,253 @@
+package org.asymetrik.web.fairnsquare.admin;
+
+import java.io.InputStream;
+import java.lang.annotation.Annotation;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.util.Collection;
+import java.util.Date;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import org.asymetrik.web.fairnsquare.admin.api.internal.AdminTokenFilter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.core.Cookie;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.Request;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.SecurityContext;
+import jakarta.ws.rs.core.UriInfo;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for AdminTokenFilter — token validation, constant-time comparison, and unconfigured-hash scenarios.
+ */
+class AdminTokenFilterTest {
+
+    private static final String PASSWORD = "password";
+    private static final String PASSWORD_HASH = sha256Hex(PASSWORD);
+
+    private AdminTokenFilter filter;
+
+    @BeforeEach
+    void setUp() {
+        filter = new AdminTokenFilter(PASSWORD_HASH);
+    }
+
+    @Test
+    void validToken_doesNotAbort() throws Exception {
+        StubContext ctx = new StubContext(PASSWORD);
+
+        filter.filter(ctx);
+
+        assertThat(ctx.abortedResponse).isNull();
+    }
+
+    @Test
+    void wrongToken_abortsWith401() throws Exception {
+        StubContext ctx = new StubContext("wrong-password");
+
+        filter.filter(ctx);
+
+        assertThat(ctx.abortedResponse).isNotNull();
+        assertThat(ctx.abortedResponse.getStatus()).isEqualTo(401);
+    }
+
+    @Test
+    void missingToken_abortsWith401() throws Exception {
+        StubContext ctx = new StubContext(null);
+
+        filter.filter(ctx);
+
+        assertThat(ctx.abortedResponse).isNotNull();
+        assertThat(ctx.abortedResponse.getStatus()).isEqualTo(401);
+    }
+
+    @Test
+    void uppercaseStoredHash_stillValidates() throws Exception {
+        // constantTimeHashEquals lowercases stored hash before parsing — accepts both cases
+        filter = new AdminTokenFilter(PASSWORD_HASH.toUpperCase());
+        StubContext ctx = new StubContext(PASSWORD);
+
+        filter.filter(ctx);
+
+        assertThat(ctx.abortedResponse).isNull();
+    }
+
+    @Test
+    void unconfiguredHash_abortsWith503() throws Exception {
+        filter = new AdminTokenFilter("");
+        StubContext ctx = new StubContext(PASSWORD);
+
+        filter.filter(ctx);
+
+        assertThat(ctx.abortedResponse).isNotNull();
+        assertThat(ctx.abortedResponse.getStatus()).isEqualTo(503);
+    }
+
+    @Test
+    void invalidHashFormat_abortsWith401() throws Exception {
+        // HexFormat.parseHex throws on garbage — constantTimeHashEquals catches and returns false → 401
+        filter = new AdminTokenFilter("not-valid-hex!!");
+        StubContext ctx = new StubContext(PASSWORD);
+
+        filter.filter(ctx);
+
+        assertThat(ctx.abortedResponse).isNotNull();
+        assertThat(ctx.abortedResponse.getStatus()).isEqualTo(401);
+    }
+
+    // --- Helpers ---
+
+    private static String sha256Hex(String input) {
+        try {
+            byte[] hash = MessageDigest.getInstance("SHA-256").digest(input.getBytes(StandardCharsets.UTF_8));
+            return java.util.HexFormat.of().formatHex(hash);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /** Minimal ContainerRequestContext stub — only getHeaderString and abortWith are implemented. */
+    private static class StubContext implements ContainerRequestContext {
+
+        private final String token;
+        Response abortedResponse = null;
+
+        StubContext(String token) {
+            this.token = token;
+        }
+
+        @Override
+        public String getHeaderString(String name) {
+            return AdminTokenFilter.ADMIN_TOKEN_HEADER.equals(name) ? token : null;
+        }
+
+        @Override
+        public void abortWith(Response response) {
+            this.abortedResponse = response;
+        }
+
+        @Override
+        public Object getProperty(String name) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Collection<String> getPropertyNames() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void setProperty(String name, Object object) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void removeProperty(String name) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public UriInfo getUriInfo() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void setRequestUri(URI requestUri) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void setRequestUri(URI baseUri, URI requestUri) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Request getRequest() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public String getMethod() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void setMethod(String method) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public MultivaluedMap<String, String> getHeaders() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Date getDate() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Locale getLanguage() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public int getLength() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public MediaType getMediaType() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public List<MediaType> getAcceptableMediaTypes() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public List<Locale> getAcceptableLanguages() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public Map<String, Cookie> getCookies() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public boolean hasEntity() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public InputStream getEntityStream() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void setEntityStream(InputStream input) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public SecurityContext getSecurityContext() {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void setSecurityContext(SecurityContext context) {
+            throw new UnsupportedOperationException();
+        }
+    }
+}

--- a/src/doc/rules/backend-rules.md
+++ b/src/doc/rules/backend-rules.md
@@ -91,6 +91,12 @@
 
 - `split.updateExpense(id, amount, description, payer, SplitMode)` delegates to `Expense.fromJson()`, which cannot construct a `FREE` expense (FREE requires explicit per-participant shares that are not part of the update request signature). Tests exercising `updateExpense` must use `BY_NIGHT` or `BY_SHARE`. The `updateExpense` method must document this constraint with a `@throws UnsupportedOperationException` if `SplitMode.FREE` is passed.
 
+## Timing-Safe Comparisons
+
+- All equality checks on secret material — HMAC signatures, password hashes, API tokens, signed values — must use `MessageDigest.isEqual(byte[], byte[])`. `String.equals`, `String.equalsIgnoreCase`, and `Arrays.equals` must not be used for this purpose: they short-circuit on the first differing byte and leak timing information proportional to the length of the common prefix.
+- To compare two strings (e.g. hex or base64 representations), convert both to bytes with the same encoding first: `MessageDigest.isEqual(a.getBytes(StandardCharsets.UTF_8), b.getBytes(StandardCharsets.UTF_8))`.
+- The rule applies anywhere the compared value was supplied (directly or indirectly) by an external caller.
+
 ## Cryptographic Randomness
 
 - Any randomness consumed by a cryptographic operation — AES/GCM IVs, salts, nonces, key material, signed tokens, CAPTCHA challenges, anti-CSRF values — must come from `java.security.SecureRandom`. `java.util.Random`, `Math.random()`, and `ThreadLocalRandom` are forbidden in security-sensitive paths because they expose predictable internal state (LCG, 48-bit seed) that an attacker can recover from a handful of outputs.


### PR DESCRIPTION
## Summary

- **#128** — `CaptchaToken.isValid` used `String.equals` to verify HMAC signatures; replaced with `MessageDigest.isEqual` (constant-time byte comparison).
- **#127** — `AdminTokenFilter` used `equalsIgnoreCase` for SHA-256 hash comparison — timing-leaky and incorrectly case-insensitive (hex digests must be compared case-sensitively). Replaced with `MessageDigest.isEqual` on parsed bytes; stored hash is lowercased before parsing to normalise any case variation in the configured value.
- **#126** — Removed `defaultValue = "change-me-in-production"` from `@ConfigProperty("captcha.secret")`. `CAPTCHA_SECRET` is now a required env var in prod — Quarkus will refuse to start if absent. `%dev` and `%test` profile entries added to `application.properties`; `CaptchaTokenTestHelper` updated to match the new test secret.
- Adds `AdminTokenFilterTest` (6 tests, plain JUnit stub — no Mockito).
- Adds "Timing-Safe Comparisons" rule to `backend-rules.md`.

Closes #126, closes #127, closes #128.

## Test plan

- [x] `AdminTokenFilterTest` — 6/6 passing (valid, wrong, missing, uppercase hash, unconfigured, malformed hex)
- [x] `CaptchaServiceTest` — 27/27 passing (HMAC round-trip tests cover the constant-time path)
- [x] Full backend suite — **322/322 passing**, no regressions
- [x] No frontend changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)