### PR TITLE
security: harden CORS defaults and replace weak test admin hash (#130, #135)

### DIFF
--- a/fairnsquare-app/src/main/resources/application.properties
+++ b/fairnsquare-app/src/main/resources/application.properties
@@ -12,9 +12,11 @@ quarkus.jvm-options=-Djava.awt.headless=true
 quarkus.http.port=8080
 quarkus.http.host=0.0.0.0
 
-# CORS - Allow frontend dev server
+# CORS — origins must be provided via env var in prod; localhost entries are dev-only
 quarkus.http.cors.enabled=true
-quarkus.http.cors.origins=${FAIRNSQUARE_CORS_ORIGINS:http://localhost:5173,http://localhost:8080}
+quarkus.http.cors.origins=${FAIRNSQUARE_CORS_ORIGINS}
+quarkus.http.cors.methods=GET,POST,DELETE,PATCH,OPTIONS
+%dev.quarkus.http.cors.origins=http://localhost:5173,http://localhost:8080
 
 # Health Checks
 quarkus.smallrye-health.root-path=/q/health
@@ -90,8 +92,8 @@ captcha.token-ttl-seconds=${CAPTCHA_TOKEN_TTL_SECONDS:3600}
 # =============================================================================
 # SHA-256 hash of the admin password (set ADMIN_PASSWORD_HASH env var in production)
 admin.password-hash=${ADMIN_PASSWORD_HASH:}
-# Test password: 'password' (sha256: 5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8)
-%test.admin.password-hash=5e884898da28047151d0e56f8dc6292773603d0d6aabbdd62a11ef721d1542d8
+# Test password: 'test-admin-secret-fairnsquare' (sha256: b19eca9b698d7465f938dca5e4ce7feb6f814af893b81fc30ea790164191fa76)
+%test.admin.password-hash=b19eca9b698d7465f938dca5e4ce7feb6f814af893b81fc30ea790164191fa76
 # =============================================================================
 # Container Image Configuration
 # =============================================================================

--- a/fairnsquare-app/src/test/java/org/asymetrik/web/fairnsquare/admin/AdminTokenFilterTest.java
+++ b/fairnsquare-app/src/test/java/org/asymetrik/web/fairnsquare/admin/AdminTokenFilterTest.java
@@ -31,7 +31,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 class AdminTokenFilterTest {
 
-    private static final String PASSWORD = "password";
+    private static final String PASSWORD = "test-admin-secret-fairnsquare";
     private static final String PASSWORD_HASH = sha256Hex(PASSWORD);
 
     private AdminTokenFilter filter;

--- a/src/main/doc/implementation/2026-04-25-Security-cors-and-test-hash.md
+++ b/src/main/doc/implementation/2026-04-25-Security-cors-and-test-hash.md
@@ -1,0 +1,37 @@
+# Security: CORS Defaults and Test Admin Hash
+
+## What, Why and Constraints
+
+**What**: Two security hardening changes bundled in one PR (fixes #130 and #135).
+
+1. **CORS defaults (#130)** — The base `application.properties` previously defaulted `FAIRNSQUARE_CORS_ORIGINS` to `http://localhost:5173,http://localhost:8080`, meaning any deployment that omitted the env var would silently accept requests from localhost origins in production. Additionally, no `quarkus.http.cors.methods` restriction was set, leaving all HTTP methods allowed by CORS.
+
+2. **Weak test admin hash (#135)** — The `%test.admin.password-hash` was the SHA-256 of `"password"` — a well-known dictionary word. Although this hash is only used in the test profile, having it committed in source enables an attacker who discovers it to immediately reverse it using rainbow tables, potentially influencing development assumptions.
+
+**Constraints**: Followed the same pattern established by `captcha.secret` in PR #145: no default in the base property (required env var for prod), profile-specific values in `application.properties` for dev and test.
+
+## How
+
+### #130 — CORS
+
+**`fairnsquare-app/src/main/resources/application.properties`**
+
+- Removed the `:http://localhost:5173,http://localhost:8080` fallback from the base `quarkus.http.cors.origins` property. The env var `FAIRNSQUARE_CORS_ORIGINS` is now required in production; Quarkus will refuse to start if it is absent.
+- Added `%dev.quarkus.http.cors.origins=http://localhost:5173,http://localhost:8080` so dev mode continues to work without any env var.
+- Added `quarkus.http.cors.methods=GET,POST,DELETE,PATCH,OPTIONS` to restrict the CORS pre-flight allowlist to the methods the API actually uses, rather than the Quarkus default of all methods.
+
+### #135 — Test admin hash
+
+**`fairnsquare-app/src/main/resources/application.properties`**
+
+- Replaced `%test.admin.password-hash` value (SHA-256 of `"password"`) with the SHA-256 of `"test-admin-secret-fairnsquare"` — a non-dictionary string that cannot be reversed with a rainbow table.
+- Updated the inline comment to document the new test password.
+
+**`fairnsquare-app/src/test/java/org/asymetrik/web/fairnsquare/admin/AdminTokenFilterTest.java`**
+
+- Updated `PASSWORD` constant from `"password"` to `"test-admin-secret-fairnsquare"` so the unit test continues to compute and compare the correct hash.
+
+## Tests
+
+- `AdminTokenFilterTest` (6 unit tests) — all pass with the new password string. The test computes the hash inline via `sha256Hex(PASSWORD)` so it always stays in sync with the constant.
+- Full backend suite: **322 tests, 0 failures**.


### PR DESCRIPTION
## Summary

- **#130**: Remove `localhost` fallback from `FAIRNSQUARE_CORS_ORIGINS` — the env var is now required in production (Quarkus refuses to start if absent). Dev profile keeps the localhost entries. Added `quarkus.http.cors.methods` to restrict the CORS allowlist to the methods the API actually uses.
- **#135**: Replace `%test.admin.password-hash` (sha256 of `"password"`, reversible by any rainbow table) with sha256 of `"test-admin-secret-fairnsquare"`. Updated `AdminTokenFilterTest.PASSWORD` constant to match.

## Test plan

- [x] `AdminTokenFilterTest` (6 unit tests) — all pass with new password string
- [x] Full backend suite: 322 tests, 0 failures

Closes #130
Closes #135

🤖 Generated with [Claude Code](https://claude.com/claude-code)