### PR TITLE
security: hash split IDs in logs and add cache-control headers (#131)

### DIFF
--- a/fairnsquare-app/src/main/java/org/asymetrik/web/fairnsquare/sharedkernel/logging/LogTag.java
+++ b/fairnsquare-app/src/main/java/org/asymetrik/web/fairnsquare/sharedkernel/logging/LogTag.java
@@ -15,6 +15,9 @@ import java.lang.annotation.Target;
  * </pre>
  *
  * This will produce a log entry containing {@code splitId=<value>}.
+ * <p>
+ * For parameters that act as capability credentials (e.g. NanoID-based split identifiers), set {@code sensitive=true}.
+ * The interceptor will log a truncated SHA-256 hash instead of the raw value.
  */
 @Target(ElementType.PARAMETER)
 @Retention(RetentionPolicy.RUNTIME)
@@ -24,4 +27,10 @@ public @interface LogTag {
      * The tag name to use in the log entry.
      */
     String value();
+
+    /**
+     * When {@code true}, the interceptor logs a truncated SHA-256 hash of the value instead of the raw value. Use for
+     * parameters that function as capability credentials (e.g. split IDs).
+     */
+    boolean sensitive() default false;
 }

--- a/fairnsquare-app/src/main/java/org/asymetrik/web/fairnsquare/sharedkernel/logging/internal/LogInterceptor.java
+++ b/fairnsquare-app/src/main/java/org/asymetrik/web/fairnsquare/sharedkernel/logging/internal/LogInterceptor.java
@@ -3,6 +3,10 @@ package org.asymetrik.web.fairnsquare.sharedkernel.logging.internal;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -61,7 +65,8 @@ public class LogInterceptor {
         for (int i = 0; i < parameters.length; i++) {
             LogTag logTag = findLogTag(parameters[i]);
             if (logTag != null) {
-                tags.put(logTag.value(), args[i]);
+                Object value = logTag.sensitive() ? hashValue(args[i]) : args[i];
+                tags.put(logTag.value(), value);
             }
         }
 
@@ -87,5 +92,18 @@ public class LogInterceptor {
             }
         }
         return null;
+    }
+
+    private static String hashValue(Object value) {
+        if (value == null) {
+            return "null";
+        }
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest(value.toString().getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(hash).substring(0, 16);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 algorithm not available", e);
+        }
     }
 }

--- a/fairnsquare-app/src/main/java/org/asymetrik/web/fairnsquare/split/api/SplitApi.java
+++ b/fairnsquare-app/src/main/java/org/asymetrik/web/fairnsquare/split/api/SplitApi.java
@@ -1,0 +1,18 @@
+package org.asymetrik.web.fairnsquare.split.api;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import jakarta.ws.rs.NameBinding;
+
+/**
+ * JAX-RS name binding annotation applied to all split endpoints. Used by {@link SplitCacheControlFilter} to add
+ * security headers to every response from the split API.
+ */
+@NameBinding
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface SplitApi {
+}

--- a/fairnsquare-app/src/main/java/org/asymetrik/web/fairnsquare/split/api/SplitCacheControlFilter.java
+++ b/fairnsquare-app/src/main/java/org/asymetrik/web/fairnsquare/split/api/SplitCacheControlFilter.java
@@ -1,0 +1,27 @@
+package org.asymetrik.web.fairnsquare.split.api;
+
+import java.io.IOException;
+
+import jakarta.ws.rs.container.ContainerRequestContext;
+import jakarta.ws.rs.container.ContainerResponseContext;
+import jakarta.ws.rs.container.ContainerResponseFilter;
+import jakarta.ws.rs.ext.Provider;
+
+/**
+ * Adds security-relevant HTTP response headers to all split API responses (bound via {@link SplitApi}).
+ * <p>
+ * Split IDs act as capability credentials: whoever holds the URL has full access to the split. These headers prevent
+ * the URL from leaking through shared caches, insecure transport, or the {@code Referer} header.
+ */
+@Provider
+@SplitApi
+public class SplitCacheControlFilter implements ContainerResponseFilter {
+
+    @Override
+    public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext)
+            throws IOException {
+        responseContext.getHeaders().putSingle("Cache-Control", "private, no-store");
+        responseContext.getHeaders().putSingle("Strict-Transport-Security", "max-age=31536000");
+        responseContext.getHeaders().putSingle("Referrer-Policy", "no-referrer");
+    }
+}

--- a/fairnsquare-app/src/main/java/org/asymetrik/web/fairnsquare/split/api/SplitResource.java
+++ b/fairnsquare-app/src/main/java/org/asymetrik/web/fairnsquare/split/api/SplitResource.java
@@ -44,6 +44,7 @@ import org.asymetrik.web.fairnsquare.split.service.SplitUseCases;
 /**
  * REST resource for managing splits.
  */
+@SplitApi
 @Path("/api/splits")
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)

--- a/fairnsquare-app/src/main/java/org/asymetrik/web/fairnsquare/split/service/SplitUseCases.java
+++ b/fairnsquare-app/src/main/java/org/asymetrik/web/fairnsquare/split/service/SplitUseCases.java
@@ -67,7 +67,7 @@ public class SplitUseCases {
      *
      * @return an Optional containing the split if found, empty otherwise
      */
-    public Optional<Split> getSplit(@LogTag("splitId") String splitId) {
+    public Optional<Split> getSplit(@LogTag(value = "splitId", sensitive = true) String splitId) {
         return repository.load(splitId);
     }
 
@@ -80,7 +80,8 @@ public class SplitUseCases {
      * @return an Optional containing the persisted settlement result, or empty if the split does not exist or has no
      *         persisted settlement
      */
-    public Optional<SettlementResult> getPersistedSettlement(@LogTag("splitId") String splitId) {
+    public Optional<SettlementResult> getPersistedSettlement(
+            @LogTag(value = "splitId", sensitive = true) String splitId) {
         return repository.load(splitId).flatMap(split -> Optional.ofNullable(split.getSettlement())
                 .map(s -> new SettlementResult(s, split.getParticipants())));
     }
@@ -93,7 +94,7 @@ public class SplitUseCases {
      *
      * @return an Optional containing the settlement if the split exists, empty otherwise
      */
-    public Optional<SettlementResult> calculateSettlement(@LogTag("splitId") String splitId) {
+    public Optional<SettlementResult> calculateSettlement(@LogTag(value = "splitId", sensitive = true) String splitId) {
         return repository.load(splitId).map(split -> {
             Settlement settlement = SettlementCalculator.calculate(split);
             split.settle(settlement);
@@ -110,7 +111,7 @@ public class SplitUseCases {
      *
      * @return true if the split was found and unsettled, false if the split does not exist
      */
-    public boolean unsettleSettlement(@LogTag("splitId") String splitId) {
+    public boolean unsettleSettlement(@LogTag(value = "splitId", sensitive = true) String splitId) {
         return repository.load(splitId).map(split -> {
             split.clearSettlement();
             repository.save(split);
@@ -126,7 +127,7 @@ public class SplitUseCases {
      *
      * @return true if the split exists, false otherwise
      */
-    public boolean exists(@LogTag("splitId") String splitId) {
+    public boolean exists(@LogTag(value = "splitId", sensitive = true) String splitId) {
         return repository.exists(splitId);
     }
 
@@ -140,7 +141,8 @@ public class SplitUseCases {
      *
      * @return an Optional containing the created participant if the split exists, empty otherwise
      */
-    public Optional<Participant> addParticipant(@LogTag("splitId") String splitId, AddParticipantRequest request) {
+    public Optional<Participant> addParticipant(@LogTag(value = "splitId", sensitive = true) String splitId,
+            AddParticipantRequest request) {
         return repository.load(splitId).map(split -> {
             Participant participant = Participant.create(request.name(), request.nights(), request.shareOrDefault());
             split.addParticipant(participant);
@@ -162,8 +164,8 @@ public class SplitUseCases {
      * @return an Optional containing the updated participant if the split exists, empty otherwise. Throws
      *         ParticipantNotFoundError if the participant doesn't exist within the split.
      */
-    public Optional<Participant> updateParticipant(@LogTag("splitId") String splitId,
-            @LogTag("participantId") String participantId, UpdateParticipantRequest request) {
+    public Optional<Participant> updateParticipant(@LogTag(value = "splitId", sensitive = true) String splitId,
+            @LogTag(value = "participantId", sensitive = true) String participantId, UpdateParticipantRequest request) {
         return repository.load(splitId).map(split -> {
             Participant.Id partId = Participant.Id.of(participantId);
             Participant.SharedAccountId sharedAccountId = Participant.SharedAccountId.isValid(request.sharedAccountId())
@@ -188,7 +190,8 @@ public class SplitUseCases {
      *         ParticipantNotFoundError if the participant doesn't exist within the split. Throws
      *         ParticipantHasExpensesError if the participant has associated expenses.
      */
-    public boolean removeParticipant(@LogTag("splitId") String splitId, @LogTag("participantId") String participantId) {
+    public boolean removeParticipant(@LogTag(value = "splitId", sensitive = true) String splitId,
+            @LogTag(value = "participantId", sensitive = true) String participantId) {
         return repository.load(splitId).map(split -> {
             Participant.Id partId = Participant.Id.of(participantId);
             split.removeParticipant(partId);
@@ -208,7 +211,8 @@ public class SplitUseCases {
      * @return true if the split exists and expense was removed, false if split not found. Throws ExpenseNotFoundError
      *         if the expense doesn't exist within the split.
      */
-    public boolean removeExpense(@LogTag("splitId") String splitId, @LogTag("expenseId") String expenseId) {
+    public boolean removeExpense(@LogTag(value = "splitId", sensitive = true) String splitId,
+            @LogTag(value = "expenseId", sensitive = true) String expenseId) {
         return repository.load(splitId).map(split -> {
             Expense.Id expId = Expense.Id.of(expenseId);
             split.removeExpense(expId);
@@ -230,8 +234,8 @@ public class SplitUseCases {
      * @return an Optional containing the updated expense if the split exists, empty otherwise. Throws
      *         ExpenseNotFoundError if the expense doesn't exist within the split.
      */
-    public Optional<Expense> updateExpense(@LogTag("splitId") String splitId, @LogTag("expenseId") String expenseId,
-            UpdateExpenseRequest request) {
+    public Optional<Expense> updateExpense(@LogTag(value = "splitId", sensitive = true) String splitId,
+            @LogTag(value = "expenseId", sensitive = true) String expenseId, UpdateExpenseRequest request) {
         return repository.load(splitId).map(split -> {
             Expense.Id expId = Expense.Id.of(expenseId);
             Participant.Id payerId = Participant.Id.of(request.payerId());
@@ -256,7 +260,8 @@ public class SplitUseCases {
      * @deprecated Use addExpenseByNight(), addExpenseByShare(), or addExpenseFree() instead.
      */
     @Deprecated
-    public Optional<Expense> addExpense(@LogTag("splitId") String splitId, AddExpenseRequest request) {
+    public Optional<Expense> addExpense(@LogTag(value = "splitId", sensitive = true) String splitId,
+            AddExpenseRequest request) {
         return switch (request.splitMode()) {
             case BY_NIGHT ->
                     addExpenseByNight(splitId, request.amount(), request.description(), request.payerId()).map(e -> e);
@@ -281,8 +286,8 @@ public class SplitUseCases {
      *
      * @return an Optional containing the created expense if the split exists, empty otherwise
      */
-    public Optional<ExpenseByNight> addExpenseByNight(@LogTag("splitId") String splitId, BigDecimal amount,
-            String description, @LogTag("payerId") String payerId) {
+    public Optional<ExpenseByNight> addExpenseByNight(@LogTag(value = "splitId", sensitive = true) String splitId,
+            BigDecimal amount, String description, @LogTag(value = "payerId", sensitive = true) String payerId) {
         return repository.load(splitId).map(split -> {
             Participant.Id payer = Participant.Id.of(payerId);
             split.validatePayerExists(payer);
@@ -310,8 +315,8 @@ public class SplitUseCases {
      *
      * @return an Optional containing the created expense if the split exists, empty otherwise
      */
-    public Optional<ExpenseByShare> addExpenseByShare(@LogTag("splitId") String splitId, BigDecimal amount,
-            String description, @LogTag("payerId") String payerId) {
+    public Optional<ExpenseByShare> addExpenseByShare(@LogTag(value = "splitId", sensitive = true) String splitId,
+            BigDecimal amount, String description, @LogTag(value = "payerId", sensitive = true) String payerId) {
         return repository.load(splitId).map(split -> {
             Participant.Id payer = Participant.Id.of(payerId);
             split.validatePayerExists(payer);
@@ -335,7 +340,8 @@ public class SplitUseCases {
      * @return an Optional containing the created expense if the split exists, empty otherwise. Throws
      *         InvalidSharesError if shares don't sum to amount or if any participant ID is invalid.
      */
-    public Optional<ExpenseFree> addExpenseFree(@LogTag("splitId") String splitId, AddFreeExpenseRequest request) {
+    public Optional<ExpenseFree> addExpenseFree(@LogTag(value = "splitId", sensitive = true) String splitId,
+            AddFreeExpenseRequest request) {
         return repository.load(splitId).map(split -> {
             Participant.Id payer = Participant.Id.of(request.payerId());
             split.validatePayerExists(payer);

--- a/fairnsquare-app/src/test/java/org/asymetrik/web/fairnsquare/sharedkernel/logging/LogInterceptorTest.java
+++ b/fairnsquare-app/src/test/java/org/asymetrik/web/fairnsquare/sharedkernel/logging/LogInterceptorTest.java
@@ -3,7 +3,10 @@ package org.asymetrik.web.fairnsquare.sharedkernel.logging;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
 import java.util.ArrayList;
+import java.util.HexFormat;
 import java.util.List;
 import java.util.logging.Handler;
 import java.util.logging.Level;
@@ -118,6 +121,19 @@ class LogInterceptorTest {
         service.greet("Delta");
 
         assertThat(logHandler.getMessages()).anyMatch(msg -> msg.matches(".*duration=\\d+ms.*"));
+    }
+
+    @Test
+    void shouldHashSensitiveTagValues() throws Exception {
+        String rawId = "super-secret-split-id";
+        service.withSensitiveTag(rawId);
+
+        String expectedHash = HexFormat.of()
+                .formatHex(MessageDigest.getInstance("SHA-256").digest(rawId.getBytes(StandardCharsets.UTF_8)))
+                .substring(0, 16);
+
+        assertThat(logHandler.getMessages())
+                .anyMatch(msg -> msg.contains("id=" + expectedHash) && !msg.contains(rawId));
     }
 
     /**

--- a/fairnsquare-app/src/test/java/org/asymetrik/web/fairnsquare/sharedkernel/logging/LoggedTestService.java
+++ b/fairnsquare-app/src/test/java/org/asymetrik/web/fairnsquare/sharedkernel/logging/LoggedTestService.java
@@ -34,4 +34,8 @@ public class LoggedTestService {
     public void failing(@LogTag("id") String id) {
         throw new IllegalStateException("test failure for " + id);
     }
+
+    public void withSensitiveTag(@LogTag(value = "id", sensitive = true) String id) {
+        // method to verify sensitive values are hashed in logs
+    }
 }

--- a/fairnsquare-app/src/test/java/org/asymetrik/web/fairnsquare/split/api/SplitSecurityHeadersTest.java
+++ b/fairnsquare-app/src/test/java/org/asymetrik/web/fairnsquare/split/api/SplitSecurityHeadersTest.java
@@ -1,0 +1,56 @@
+package org.asymetrik.web.fairnsquare.split.api;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.equalTo;
+
+import org.asymetrik.web.fairnsquare.CaptchaTokenTestHelper;
+import org.asymetrik.web.fairnsquare.infrastructure.filesystem.TempStorageTestResource;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.http.ContentType;
+
+/**
+ * Verifies that responses to /api/splits/** carry the required security headers from {@link SplitCacheControlFilter}.
+ */
+@QuarkusTest
+@QuarkusTestResource(TempStorageTestResource.class)
+class SplitSecurityHeadersTest {
+
+    @Test
+    void splitEndpointsShouldCarryCacheControlHeader() {
+        String splitId = createSplit();
+
+        given().when().get("/api/splits/" + splitId).then().statusCode(200).header("Cache-Control",
+                "private, no-store");
+    }
+
+    @Test
+    void splitEndpointsShouldCarryStrictTransportSecurityHeader() {
+        String splitId = createSplit();
+
+        given().when().get("/api/splits/" + splitId).then().statusCode(200).header("Strict-Transport-Security",
+                "max-age=31536000");
+    }
+
+    @Test
+    void splitEndpointsShouldCarryReferrerPolicyHeader() {
+        String splitId = createSplit();
+
+        given().when().get("/api/splits/" + splitId).then().statusCode(200).header("Referrer-Policy", "no-referrer");
+    }
+
+    @Test
+    void nonSplitEndpointsShouldNotCarrySplitCacheControlHeader() {
+        given().when().get("/q/health").then().header("Cache-Control", not(equalTo("private, no-store")));
+    }
+
+    private String createSplit() {
+        return given().contentType(ContentType.JSON).header("X-Captcha-Token", CaptchaTokenTestHelper.generateToken())
+                .body("""
+                        {"name": "Security Header Test Split"}
+                        """).when().post("/api/splits").then().statusCode(201).extract().path("id");
+    }
+}

--- a/src/doc/rules/backend-rules.md
+++ b/src/doc/rules/backend-rules.md
@@ -97,6 +97,15 @@
 - To compare two strings (e.g. hex or base64 representations), convert both to bytes with the same encoding first: `MessageDigest.isEqual(a.getBytes(StandardCharsets.UTF_8), b.getBytes(StandardCharsets.UTF_8))`.
 - The rule applies anywhere the compared value was supplied (directly or indirectly) by an external caller.
 
+## Capability Credentials in Logs
+
+- Parameters that function as capability credentials (e.g. NanoID-based identifiers where knowing the value alone grants access to a resource) must never be logged in raw form. Annotate them with `@LogTag(value = "...", sensitive = true)` so the interceptor logs a truncated SHA-256 hash instead. The hash is stable enough for log correlation but not reversible.
+- The rule applies to any identifier whose knowledge alone grants access — not just split IDs, but participant IDs, expense IDs, or any future token-like identifier used as an access key.
+
+## JAX-RS Response Filters — Scoping
+
+- Response filters that apply security headers to a subset of endpoints must use a `@NameBinding` annotation rather than path-string matching inside `ContainerResponseFilter.filter()`. Apply the binding annotation to the resource class (not individual methods) to cover all current and future methods automatically.
+
 ## Cryptographic Randomness
 
 - Any randomness consumed by a cryptographic operation — AES/GCM IVs, salts, nonces, key material, signed tokens, CAPTCHA challenges, anti-CSRF values — must come from `java.security.SecureRandom`. `java.util.Random`, `Math.random()`, and `ThreadLocalRandom` are forbidden in security-sensitive paths because they expose predictable internal state (LCG, 48-bit seed) that an attacker can recover from a handful of outputs.

--- a/src/main/doc/implementation/2026-04-27-Security-split-id-log-hash-and-cache-control.md
+++ b/src/main/doc/implementation/2026-04-27-Security-split-id-log-hash-and-cache-control.md
@@ -1,0 +1,52 @@
+# Security: Split ID Log Hashing and Cache-Control Headers (#131)
+
+## What, Why and Constraints
+
+**What:** Two related security fixes addressing split capability URL leakage (GitHub issue #131):
+1. Raw split IDs (and participant/expense IDs) were written to log files via `@LogTag`. Since the split URL is the sole credential for accessing a split, any log access was equivalent to full split access.
+2. Split API responses lacked `Cache-Control`, `Strict-Transport-Security`, and `Referrer-Policy` headers, allowing the capability URL to leak through shared HTTP caches, insecure transport, and `Referer` headers on external link clicks.
+
+**Why:** The access model is "the URL is the credential". A 21-char NanoID provides ~125 bits of entropy (not guessable), but it is fully exposed in logs on every service call. An attacker with log access (or an insider) has read/write access to every split. The cache and transport leakage vectors are lower-impact but straightforward to close.
+
+**Constraints:**
+- `Interceptors must be purely observational` (backend-rules) — hashing happens in the interceptor without altering return values or suppressing exceptions.
+- `@NameBinding` pattern for JAX-RS filters — consistent with `@AdminProtected` and `@CaptchaProtected` in the codebase.
+- SHA-256 truncated to 16 hex chars — same algorithm as `AdminService.hashId`, providing a stable opaque token for log correlation without reversibility.
+
+## How
+
+### Step 1 — `@LogTag` annotation extended with `sensitive` attribute
+`sharedkernel/logging/LogTag.java`: added `boolean sensitive() default false`. Default is `false` so all existing usages are backward-compatible.
+
+### Step 2 — `LogInterceptor` hashes sensitive values
+`sharedkernel/logging/internal/LogInterceptor.java`: added a private `hashValue(Object)` method using `MessageDigest SHA-256`, truncated to 16 hex chars. In `extractTags()`, when `logTag.sensitive() == true`, the hashed value is logged instead of the raw value.
+
+### Step 3 — `SplitUseCases` ID parameters marked sensitive
+`split/service/SplitUseCases.java`: all 16 `@LogTag` annotations on `splitId`, `participantId`, `expenseId`, and `payerId` parameters updated to `sensitive = true`. Raw IDs no longer appear in any log line.
+
+### Step 4 — `@SplitApi` name binding annotation created
+`split/api/SplitApi.java`: new `@NameBinding` annotation following the project's established filter pattern (`@AdminProtected`, `@CaptchaProtected`). Applied to `SplitResource` at the class level, so all split endpoints automatically bind to any filter carrying the annotation.
+
+### Step 5 — `SplitCacheControlFilter` response filter added
+`split/api/SplitCacheControlFilter.java`: new `ContainerResponseFilter` annotated with `@Provider @SplitApi`. Sets three headers on every split API response:
+- `Cache-Control: private, no-store` — prevents shared HTTP proxy caching of split URLs
+- `Strict-Transport-Security: max-age=31536000` — enforces HTTPS at the HTTP layer (complements `force_https` in `fly.toml`)
+- `Referrer-Policy: no-referrer` — prevents split URLs leaking in `Referer` headers to external sites
+
+### Step 6 — `SplitResource` annotated with `@SplitApi`
+`split/api/SplitResource.java`: added `@SplitApi` at the class level, binding all split endpoints to the response filter.
+
+## Tests
+
+**Unit / integration (LogInterceptor):**
+- `LoggedTestService.withSensitiveTag()`: new test-only method with `@LogTag(value = "id", sensitive = true)`.
+- `LogInterceptorTest.shouldHashSensitiveTagValues()`: verifies the raw ID is absent from the log and the expected 16-char SHA-256 hash is present.
+
+**Integration (HTTP headers):**
+- `SplitSecurityHeadersTest`: new `@QuarkusTest` verifying:
+  - `Cache-Control: private, no-store` on `GET /api/splits/{id}`
+  - `Strict-Transport-Security: max-age=31536000` on `GET /api/splits/{id}`
+  - `Referrer-Policy: no-referrer` on `GET /api/splits/{id}`
+  - Non-split endpoint (`/q/health`) does NOT receive `Cache-Control: private, no-store`
+
+All 327 tests pass.


### PR DESCRIPTION
## Summary

- **Log hashing**: Raw split/participant/expense/payer IDs were written to log files on every service call via `@LogTag`. Since the split URL is the sole credential, log access = full split access. Added `sensitive=true` to `@LogTag`; `LogInterceptor` now logs a truncated SHA-256 hash instead. All 16 ID parameters in `SplitUseCases` marked sensitive.
- **Response headers**: Added `SplitCacheControlFilter` (bound via new `@SplitApi` `@NameBinding`) to set `Cache-Control: private, no-store`, `Strict-Transport-Security: max-age=31536000`, and `Referrer-Policy: no-referrer` on all `/api/splits/**` responses — preventing leakage via shared caches, insecure transport, and `Referer` headers.
- **Backend rules**: Added two new rules documenting the capability-credential logging pattern and the `@NameBinding` filter scoping requirement.

Closes #131.

## Test plan

- [ ] `LogInterceptorTest.shouldHashSensitiveTagValues` — verifies raw ID absent from log, 16-char hex hash present
- [ ] `SplitSecurityHeadersTest` — integration tests verifying all three headers on `GET /api/splits/{id}` and absence on non-split endpoints
- [ ] Full suite: 327 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)